### PR TITLE
Gunicorn, single mp3 handling, m4a handling

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,9 @@ on:
 #   schedule:
 #     - cron: '45 16 * * *'
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - develop
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,4 +182,5 @@ CMD python manage.py migrate && \
 	--worker-tmp-dir /dev/shm \
 	--workers=2 \
 	--threads=4 \
-	--worker-class=gthread
+	--worker-class=gthread \
+	--reload

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,4 +233,4 @@ COPY --from=ffbuild /opt/ffmpeg/bin/ffprobe /usr/bin
 # USER 99:100
 
 # start server
-CMD python manage.py migrate && gunicorn bragibooks_proj.wsgi --bind 0.0.0.0:8000
+CMD python manage.py migrate && gunicorn bragibooks_proj.wsgi --bind 0.0.0.0:8000 --timeout 1200

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,15 +38,10 @@ ARG PREFIX=/opt/ffmpeg
 ARG MAKEFLAGS="-j$(nproc)"
 
 ENV FFMPEG_VERSION=snapshot \
-	FREETYPE_VERSION=2.10.1 \
 	LAME_VERSION=3.100 \
 	OPUS_VERSION=1.3.1 \
-	X264_VERSION=x264-master \
-	X265_VERSION=3.4 \
-	ZIMG_VERSION=2.9.3 \
 	SRC=/usr/local
 
-ARG FREETYPE_SHA256SUM="3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110 freetype-${FREETYPE_VERSION}.tar.gz"
 ARG OPUS_SHA256SUM="65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d opus-${OPUS_VERSION}.tar.gz"
 
 ### fdk-aac https://github.com/mstorsjo/fdk-aac
@@ -59,31 +54,6 @@ RUN \
 		rm fdk-aac-master.zip && \
 		autoreconf -fiv && \
 		./configure --prefix="${PREFIX}" --disable-shared --datadir="${DIR}" && \
-		make && \
-		make install
-
-## x264 http://www.videolan.org/developers/x264.html
-RUN \
-		DIR=/tmp/x264 && \
-		mkdir -p ${DIR} && \
-		cd ${DIR} && \
-		curl -sL https://code.videolan.org/videolan/x264/-/archive/master/${X264_VERSION}.tar.bz2 | \
-		tar -jx --strip-components=1 && \
-		./configure --prefix="${PREFIX}" --enable-static --enable-pic --disable-cli && \
-		make && \
-		make install
-
-### x265 http://x265.org/
-RUN \
-		DIR=/tmp/x265 && \
-		mkdir -p ${DIR} && \
-		cd ${DIR} && \
-		curl -sL http://anduin.linuxfromscratch.org/BLFS/x265/x265_${X265_VERSION}.tar.gz  | \
-		tar -zx && \
-		cd x265_${X265_VERSION}/build/linux && \
-		find . -mindepth 1 ! -name 'make-Makefiles.bash' -and ! -name 'multilib.sh' -exec rm -r {} + && \
-		cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$PREFIX" -DENABLE_SHARED:BOOL=OFF -DSTATIC_LINK_CRT:BOOL=ON -DENABLE_CLI:BOOL=OFF ../../source && \
-		sed -i 's/-lgcc_s/-lgcc_eh/g' x265.pc && \
 		make && \
 		make install
 
@@ -111,30 +81,6 @@ RUN \
 		make && \
 		make install
 
-## freetype https://www.freetype.org/
-RUN  \
-		DIR=/tmp/freetype && \
-		mkdir -p ${DIR} && \
-		cd ${DIR} && \
-		curl -sLO https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
-		echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
-		tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
-		./configure --prefix="${PREFIX}" --enable-static --disable-shared && \
-		make && \
-		make install
-
-## Zimg
-RUN  \
-		DIR=/tmp/zimg && \
-		mkdir -p ${DIR} && \
-		cd ${DIR} && \
-		curl -sLO https://github.com/sekrit-twc/zimg/archive/release-${ZIMG_VERSION}.tar.gz &&\
-		tar -zx --strip-components=1 -f release-${ZIMG_VERSION}.tar.gz && \
-		./autogen.sh && \
-		./configure --enable-static -prefix="${PREFIX}" --disable-shared && \
-		make && \
-		make install
-
 ## ffmpeg https://ffmpeg.org/
 RUN  \
 		DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
@@ -148,12 +94,8 @@ RUN \
 		--enable-gpl \
 		--enable-version3 \
 		--enable-libfdk-aac \
-		--enable-libfreetype \
 		--enable-libmp3lame \
 		--enable-libopus \
-		--enable-libx264 \
-		--enable-libx265 \
-		--enable-libzimg \
 		--enable-nonfree \
 		--enable-openssl \
 		--pkg-config-flags="--static" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,4 +233,4 @@ COPY --from=ffbuild /opt/ffmpeg/bin/ffprobe /usr/bin
 # USER 99:100
 
 # start server
-CMD python manage.py runserver 0.0.0.0:8000
+CMD python manage.py migrate && gunicorn bragibooks_proj.wsgi --bind 0.0.0.0:8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -175,4 +175,11 @@ COPY --from=ffbuild /opt/ffmpeg/bin/ffprobe /usr/bin
 # USER 99:100
 
 # start server
-CMD python manage.py migrate && gunicorn bragibooks_proj.wsgi --bind 0.0.0.0:8000 --timeout 1200
+CMD python manage.py migrate && \
+	gunicorn bragibooks_proj.wsgi \
+	--bind 0.0.0.0:8000 \
+	--timeout 1200 \
+	--worker-tmp-dir /dev/shm \
+	--workers=2 \
+	--threads=4 \
+	--worker-class=gthread

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ To run Bragi Books as a container, you need to pass some paramaters in the run c
     
 Which all together should look like: 
 
-	docker run --rm -d -v /path/to//input:/input -v /path/to//output:/output -v /appdata/bragibooks/config:/config -p 8000:8000/tcp -e LOG_LEVEL=WARNING bragibooks:latest
+	docker run --rm -d -v /path/to/input:/input -v /path/to/output:/output -v /appdata/bragibooks/config:/config -p 8000:8000/tcp -e LOG_LEVEL=WARNING ghcr.io/djdembeck/bragibooks:latest
 	
 ---
 
-### Webserver (Django):
-  - `python manage.py makemigrations`
+### Webserver (Gunicorn + Django):
+From within the `bragibooks` folder you cloned:
   - `python manage.py migrate`
-  - `python manage.py runserver`
+  - `gunicorn bragibooks_proj.wsgi`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,22 @@ From within the `bragibooks` folder you cloned:
 ### CLI:
 You can run the core logic from the terminal without any running server or database
 
+
+```
+usage: merge_cli.py [-h] -i INPUTS [INPUTS ...] [--log_level LOG_LEVEL]
+
+Bragi Books merge cli
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INPUTS [INPUTS ...], --inputs INPUTS [INPUTS ...]
+                        Input paths to process
+  --log_level LOG_LEVEL
+                        Set logging level
+```
   - Check the user editable variables in [merge_cli.py](importer/merge_cli.py), and see if there's anything you need to change.
-  - After that, just run `python importer/manage_cli.py` and it will walk you through what you need to get going.
+
+  - On first run, you will be prompted to signin to Audible. This is a one-time process that will be saved to the `config` folder.
 
 ---
 

--- a/bragibooks_proj/settings.py
+++ b/bragibooks_proj/settings.py
@@ -31,7 +31,7 @@ with open(SECRET_PATH) as f:
 	SECRET_KEY = f.read().strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 

--- a/bragibooks_proj/settings.py
+++ b/bragibooks_proj/settings.py
@@ -17,9 +17,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # config section for docker
 if os.path.isdir("/config"):
-    CONFIG_DIR = os.path.abspath("/config")
+	CONFIG_DIR = os.path.abspath("/config")
 else:
-    CONFIG_DIR = os.path.join(BASE_DIR, 'config')
+	CONFIG_DIR = os.path.join(BASE_DIR, 'config')
 
 SECRET_PATH = os.path.join(CONFIG_DIR, 'secret_key.txt')
 
@@ -28,7 +28,7 @@ SECRET_PATH = os.path.join(CONFIG_DIR, 'secret_key.txt')
 
 # SECURITY WARNING: keep the secret key used in production secret!
 with open(SECRET_PATH) as f:
-    SECRET_KEY = f.read().strip()
+	SECRET_KEY = f.read().strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -38,41 +38,41 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
-    'importer',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+	'importer',
+	'django.contrib.admin',
+	'django.contrib.auth',
+	'django.contrib.contenttypes',
+	'django.contrib.sessions',
+	'django.contrib.messages',
+	'django.contrib.staticfiles',
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+	'django.middleware.security.SecurityMiddleware',
+	'django.contrib.sessions.middleware.SessionMiddleware',
+	'django.middleware.common.CommonMiddleware',
+	'django.middleware.csrf.CsrfViewMiddleware',
+	'django.contrib.auth.middleware.AuthenticationMiddleware',
+	'django.contrib.messages.middleware.MessageMiddleware',
+	'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'bragibooks_proj.urls'
 
 TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
-        },
-    },
+	{
+		'BACKEND': 'django.template.backends.django.DjangoTemplates',
+		'DIRS': [],
+		'APP_DIRS': True,
+		'OPTIONS': {
+			'context_processors': [
+				'django.template.context_processors.debug',
+				'django.template.context_processors.request',
+				'django.contrib.auth.context_processors.auth',
+				'django.contrib.messages.context_processors.messages',
+			],
+		},
+	},
 ]
 
 WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
@@ -81,28 +81,28 @@ WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(CONFIG_DIR, 'db.sqlite3'),
-    }
+	'default': {
+		'ENGINE': 'django.db.backends.sqlite3',
+		'NAME': os.path.join(CONFIG_DIR, 'db.sqlite3'),
+	}
 }
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+	{
+		'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+	},
+	{
+		'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+	},
 ]
 
 # Internationalization
@@ -126,23 +126,23 @@ STATIC_URL = '/static/'
 # Set environment variable DJANGO_LOG_LEVEL to desired level
 # https://docs.djangoproject.com/en/2.2/topics/logging/
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'level': os.getenv('LOG_LEVEL', 'INFO'),
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'root': {
-        'handlers': ['console'],
-        'level': os.getenv('LOG_LEVEL', 'INFO'),
-    },
-    'loggers': {
-        'gunicorn': {  # this was what I was missing, I kept using django and not seeing any server logs
-            'level': os.getenv('LOG_LEVEL', 'INFO'),
-            'handlers': ['console'],
-            'propagate': True,
-        },
-    },
+	'version': 1,
+	'disable_existing_loggers': False,
+	'handlers': {
+		'console': {
+			'level': os.getenv('LOG_LEVEL', 'INFO'),
+			'class': 'logging.StreamHandler',
+		},
+	},
+	'root': {
+		'handlers': ['console'],
+		'level': os.getenv('LOG_LEVEL', 'INFO'),
+	},
+	'loggers': {
+		'gunicorn': {  # this was what I was missing, I kept using django and not seeing any server logs
+			'level': os.getenv('LOG_LEVEL', 'INFO'),
+			'handlers': ['console'],
+			'propagate': True,
+		},
+	},
 }

--- a/bragibooks_proj/settings.py
+++ b/bragibooks_proj/settings.py
@@ -17,9 +17,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # config section for docker
 if os.path.isdir("/config"):
-	CONFIG_DIR = os.path.abspath("/config")
+    CONFIG_DIR = os.path.abspath("/config")
 else:
-	CONFIG_DIR = os.path.join(BASE_DIR, 'config')
+    CONFIG_DIR = os.path.join(BASE_DIR, 'config')
 
 SECRET_PATH = os.path.join(CONFIG_DIR, 'secret_key.txt')
 
@@ -28,7 +28,7 @@ SECRET_PATH = os.path.join(CONFIG_DIR, 'secret_key.txt')
 
 # SECURITY WARNING: keep the secret key used in production secret!
 with open(SECRET_PATH) as f:
-	SECRET_KEY = f.read().strip()
+    SECRET_KEY = f.read().strip()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -38,41 +38,41 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
-	'importer',
-	'django.contrib.admin',
-	'django.contrib.auth',
-	'django.contrib.contenttypes',
-	'django.contrib.sessions',
-	'django.contrib.messages',
-	'django.contrib.staticfiles',
+    'importer',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
 ]
 
 MIDDLEWARE = [
-	'django.middleware.security.SecurityMiddleware',
-	'django.contrib.sessions.middleware.SessionMiddleware',
-	'django.middleware.common.CommonMiddleware',
-	'django.middleware.csrf.CsrfViewMiddleware',
-	'django.contrib.auth.middleware.AuthenticationMiddleware',
-	'django.contrib.messages.middleware.MessageMiddleware',
-	'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'bragibooks_proj.urls'
 
 TEMPLATES = [
-	{
-		'BACKEND': 'django.template.backends.django.DjangoTemplates',
-		'DIRS': [],
-		'APP_DIRS': True,
-		'OPTIONS': {
-			'context_processors': [
-				'django.template.context_processors.debug',
-				'django.template.context_processors.request',
-				'django.contrib.auth.context_processors.auth',
-				'django.contrib.messages.context_processors.messages',
-			],
-		},
-	},
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
 ]
 
 WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
@@ -81,28 +81,28 @@ WSGI_APPLICATION = 'bragibooks_proj.wsgi.application'
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 DATABASES = {
-	'default': {
-		'ENGINE': 'django.db.backends.sqlite3',
-		'NAME': os.path.join(CONFIG_DIR, 'db.sqlite3'),
-	}
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(CONFIG_DIR, 'db.sqlite3'),
+    }
 }
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-	{
-		'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-	},
-	{
-		'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-	},
-	{
-		'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-	},
-	{
-		'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-	},
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
 ]
 
 # Internationalization
@@ -130,11 +130,19 @@ LOGGING = {
     'disable_existing_loggers': False,
     'handlers': {
         'console': {
+            'level': os.getenv('LOG_LEVEL', 'INFO'),
             'class': 'logging.StreamHandler',
         },
     },
     'root': {
         'handlers': ['console'],
         'level': os.getenv('LOG_LEVEL', 'INFO'),
+    },
+    'loggers': {
+        'gunicorn': {  # this was what I was missing, I kept using django and not seeing any server logs
+            'level': os.getenv('LOG_LEVEL', 'INFO'),
+            'handlers': ['console'],
+            'propagate': True,
+        },
     },
 }

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -432,6 +432,7 @@ def m4b_data(input_data, metadata, output):
 		' '.join(args) + 
 		f" \"{in_dir}\""
 		)
+		logging.debug(f"M4B command: {m4b_cmd}")
 		os.system(m4b_cmd)
 
 		# Move obsolete input to processed folder
@@ -466,7 +467,7 @@ def m4b_data(input_data, metadata, output):
 		f'--export-chapters=\"\"' + 
 		f" \"{in_dir}\""
 		)
-
+		logging.debug(f"M4B command: {m4b_cmd}")
 		os.system(m4b_cmd)
 		
 		shutil.move(
@@ -494,6 +495,7 @@ def m4b_data(input_data, metadata, output):
 			m4b_tool + 
 			' '.join(args) + 
 			f" \"{in_dir.parent}/{in_dir.stem}.new.m4b\"")
+		logging.debug(f"M4B command: {m4b_cmd}")
 		os.system(m4b_cmd)
 
 		# Move completed file
@@ -563,6 +565,7 @@ def m4b_data(input_data, metadata, output):
 		' '.join(args) + 
 		f" \"{in_dir}\""
 		)
+		logging.debug(f"M4B command: {m4b_cmd}")
 		os.system(m4b_cmd)
 
 		# Move obsolete input to processed folder

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -348,9 +348,15 @@ def m4b_data(input_data, metadata, output):
 		'--force',
 		'--no-chapter-reindexing',
 		'--no-cleanup',
-		f'--jobs={num_cpus}',
-		'-vv'
+		f'--jobs={num_cpus}'
 	]
+
+	# Set logging level of m4b-tool depending upon log_level
+	level = logging.root.level
+	if level == logging.INFO:
+		processing_args.append('-v')
+	elif level == logging.DEBUG:
+		processing_args.append('-vvv')
 
 	# args for multiple input files in a folder
 	if (in_dir.is_dir() and num_of_files > 1) or in_ext == None:

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -228,12 +228,12 @@ def get_directory(input_take):
 								)
 	# Check if input is a file
 	elif Path(input_take).is_file():
-		dirpath = Path(input_take)
+		dirpath = input_take
 		USE_EXT_PRE = dirpath.suffix
 		USE_EXT = Path(USE_EXT_PRE).stem.split('.')[1]
 		num_of_files = 1
 
-	return dirpath, USE_EXT, num_of_files
+	return Path(dirpath), USE_EXT, num_of_files
 
 def m4b_data(input_data, metadata, output):
 	## Checks
@@ -598,7 +598,7 @@ def call(inputs):
 		# If no auth file exists, call login function
 		audible_login()
 
-	print(f"Working on: {inputs}")
+	logging.info(f"Working on: {inputs}")
 	input_data = get_directory(inputs)
 	asin = input("Audiobook ASIN: ")
 	metadata = audible_parser(asin)

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -615,4 +615,7 @@ if __name__ == "__main__":
 		logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
 	# Run through inputs
 	for inputs in args.inputs:
-		call(inputs)
+		if inputs.exists():
+			call(inputs)
+		else:
+			logging.error(f"Input \"{inputs}\" does not exist")

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -335,7 +335,7 @@ def m4b_data(input_data, metadata, output):
 		'--no-chapter-reindexing',
 		'--no-cleanup',
 		f'--jobs={num_cpus}',
-		'-v'
+		'-vv'
 	]
 
 	# args for multiple input files in a folder
@@ -388,8 +388,8 @@ def m4b_data(input_data, metadata, output):
 		if series:
 			args.append(f'--series \"{series}\"')
 
-		if in_ext == "m4b":
-			logging.info("Multiple m4b files, not converting")
+		if in_ext == "m4b" or in_ext == "m4a":
+			logging.info(f"Multiple {in_ext} files, not converting")
 			args.append(f'--no-conversion')
 
 		# m4b command with passed args
@@ -413,7 +413,7 @@ def m4b_data(input_data, metadata, output):
 			)
 		
 	# args for single m4b input file
-	elif Path(in_dir).is_file() and in_ext == "m4b":
+	elif (Path(in_dir).is_file()) and (in_ext == "m4b" or in_ext == "m4a"):
 		# Dir for completed folders to move to
 		Path(Path(in_dir).parent, 'done').mkdir(
 			parents=True,

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -486,10 +486,11 @@ def m4b_data(input_data, metadata, output):
 		else:
 			logging.warning("Couldn't find junk dir relative to input")
 
-		shutil.move(
-			f"{move_dir}",
-			f"{junk_dir}"
-		)
+		if move_dir:
+			shutil.move(
+				f"{move_dir}",
+				f"{junk_dir}"
+			)
 
 		m4b_fix_chapters(
 			f"{book_output}/{file_title}.chapters.txt",
@@ -547,10 +548,11 @@ def m4b_data(input_data, metadata, output):
 		else:
 			logging.warning("Couldn't find junk dir relative to input")
 
-		shutil.move(
-			f"{move_dir}",
-			f"{junk_dir}"
-		)
+		if move_dir:
+			shutil.move(
+				f"{move_dir}",
+				f"{junk_dir}"
+			)
 
 		logging.warning(f"Not processing chapters for  {title}, since it's an mp3")
 

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -374,24 +374,29 @@ def m4b_data(input_data, metadata, output):
 	if (in_dir.is_dir() and num_of_files > 1) or in_ext == None:
 		logging.info("Processing multiple files in a dir...")
 
+		in_dir_glob = Path(in_dir).glob('**/*')
+
 		# If multi-disc, find the extension
 		if not in_ext:
-			dir_select = sorted(Path(in_dir).glob('**/*'))[0]
-			find_ext = find_extension(dir_select)
-			in_ext = find_ext[0]
+			dir_select = sorted(in_dir_glob)[0]
+			print(dir_select)
+			in_ext = find_extension(dir_select)[1]
+			logging.debug(f"Guessed multi-disc extension to be: {in_ext}")
 		else:
 			dir_select = in_dir
 
-		# Find first file with our extension, to check rates against
+		dir_select_glob = Path(dir_select).glob('**/*')
+
+
 		first_file_index = 0
+		# Find first file with our extension, to check rates against
 		while True:
-			if Path(
-				sorted(
-					Path(dir_select).glob('**/*'))[first_file_index]
-				).suffix == f".{in_ext}":
+			files_sorted = Path(sorted(dir_select_glob)[first_file_index])
+			if files_sorted.suffix == f".{in_ext}":
 				break
 			first_file_index += 1
-		first_file = sorted(Path(dir_select).glob('**/*'))[first_file_index]
+		first_file = files_sorted
+		logging.debug(f"Got file to run mediainfo on: {first_file}")
 
 		## Mediainfo data
 		# Divide bitrate by 1k, round up,

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -319,6 +319,25 @@ def m4b_data(input_data, metadata, output):
 	)
 
 	## Array for argument use
+	# main metadata args
+	metadata_args = [
+		f"--name=\"{title}\"",
+		f"--album=\"{path_title}\"",
+		f"--artist=\"{narrator}\"",
+		f"--albumartist=\"{author}\"",
+		f"--year=\"{year}\"",
+		f"--description=\"{summary}\""
+	]
+
+	# args for merge  process
+	processing_args = [
+		'--force',
+		'--no-chapter-reindexing',
+		'--no-cleanup',
+		f'--jobs={num_cpus}',
+		'-v'
+	]
+
 	# args for multiple input files in a folder
 	if (Path(in_dir).is_dir() and num_of_files > 1) or in_ext == None:
 		logging.info("Processing multiple files in a dir...")
@@ -359,24 +378,18 @@ def m4b_data(input_data, metadata, output):
 		args = [
 			' merge',
 			f"--output-file=\"{book_output}/{file_title}.m4b\"",
-			f"--name=\"{title}\"",
-			f"--album=\"{path_title}\"",
-			f"--artist=\"{narrator}\"",
-			f"--albumartist=\"{author}\"",
-			f"--year=\"{year}\"",
-			f"--description=\"{summary}\"",
 			f"--audio-bitrate=\"{target_bitrate}\"",
-			f"--audio-samplerate=\"{target_samplerate}\"",
-			'--force',
-			'--no-chapter-reindexing',
-			'--no-cleanup',
-			f'--jobs={num_cpus}',
-			'-v'
+			f"--audio-samplerate=\"{target_samplerate}\""
 		]
+		# Add in main metadata and merge args
+		args.extend(metadata_args)
+		args.extend(processing_args)
+
 		if series:
 			args.append(f'--series \"{series}\"')
 
 		if in_ext == "m4b":
+			logging.info("Multiple m4b files, not converting")
 			args.append(f'--no-conversion')
 
 		# m4b command with passed args
@@ -433,14 +446,11 @@ def m4b_data(input_data, metadata, output):
 			)
 
 		args = [
-			' meta',
-			f"--name=\"{title}\"",
-			f"--album=\"{path_title}\"",
-			f"--artist=\"{narrator}\"",
-			f"--albumartist=\"{author}\"",
-			f"--year=\"{year}\"",
-			f"--description=\"{summary}\""
+			' meta'
 		]
+		# Add in main metadata args
+		args.extend(metadata_args)
+
 		if series:
 			args.append(f"--series \"{series}\"")
 
@@ -503,20 +513,13 @@ def m4b_data(input_data, metadata, output):
 		args = [
 			' merge',
 			f"--output-file=\"{book_output}/{file_title}.m4b\"",
-			f"--name=\"{title}\"",
-			f"--album=\"{path_title}\"",
-			f"--artist=\"{narrator}\"",
-			f"--albumartist=\"{author}\"",
-			f"--year=\"{year}\"",
-			f"--description=\"{summary}\"",
 			f"--audio-bitrate=\"{target_bitrate}\"",
-			f"--audio-samplerate=\"{target_samplerate}\"",
-			'--force',
-			'--no-chapter-reindexing',
-			'--no-cleanup',
-			f'--jobs={num_cpus}',
-			'-v'
+			f"--audio-samplerate=\"{target_samplerate}\""
 		]
+		# Add in main metadata and merge args
+		args.extend(metadata_args)
+		args.extend(processing_args)
+
 		if series:
 			args.append(f'--series \"{series}\"')
 

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -355,7 +355,6 @@ def m4b_data(input_data, metadata, output):
 		'--force',
 		'--no-chapter-reindexing',
 		'--no-cleanup',
-		'--skip-cover',
 		f'--jobs={num_cpus}'
 	]
 
@@ -543,7 +542,8 @@ def m4b_data(input_data, metadata, output):
 			' merge',
 			f"--output-file=\"{book_output}/{file_title}.m4b\"",
 			f"--audio-bitrate=\"{target_bitrate}\"",
-			f"--audio-samplerate=\"{target_samplerate}\""
+			f"--audio-samplerate=\"{target_samplerate}\"",
+			'--skip-cover'
 		]
 		# Add in main metadata and merge args
 		args.extend(metadata_args)

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -205,6 +205,7 @@ def find_extension(dirpath):
 				for x in list_of_files
 				) == 1:
 				for m4b_file in Path(dirpath).glob(f'*.{USE_EXT}'):
+					logging.debug(f"Adjusted input for {dirpath} to use single m4b file")
 					dirpath = m4b_file
 				num_of_files = 1
 			else:
@@ -212,7 +213,7 @@ def find_extension(dirpath):
 					x.endswith(f'.{USE_EXT}') 
 					for x in list_of_files
 					)
-			return USE_EXT, num_of_files
+			return dirpath, USE_EXT, num_of_files
 
 def get_directory(input_take):
 	# Check if input is a dir
@@ -230,8 +231,9 @@ def get_directory(input_take):
 		else:
 			for dirpath, dirnames, files in os.walk(input_take):
 				find_ext = find_extension(dirpath)
-				USE_EXT = find_ext[0]
-				num_of_files = find_ext[1]
+				dirpath = find_ext[0]
+				USE_EXT = find_ext[1]
+				num_of_files = find_ext[2]
 
 	# Check if input is a file
 	elif Path(input_take).is_file():
@@ -240,6 +242,9 @@ def get_directory(input_take):
 		USE_EXT = Path(USE_EXT_PRE).stem.split('.')[1]
 		num_of_files = 1
 
+	logging.debug(f"Final input path is: {dirpath}")
+	logging.debug(f"Extension is: {USE_EXT}")
+	logging.debug(f"Number of files: {num_of_files}")
 	return Path(dirpath), USE_EXT, num_of_files
 
 def m4b_data(input_data, metadata, output):
@@ -580,6 +585,9 @@ def m4b_data(input_data, metadata, output):
 
 	elif not in_ext:
 		logging.error(f"No recognized filetypes found for {title}")
+
+	else:
+		logging.error(f"Couldn't determine input type/extension for {title}")
 
 def m4b_fix_chapters(input, target, m4b_tool):
 	new_file_content = ""

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -355,6 +355,7 @@ def m4b_data(input_data, metadata, output):
 		'--force',
 		'--no-chapter-reindexing',
 		'--no-cleanup',
+		'--skip-cover',
 		f'--jobs={num_cpus}'
 	]
 

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -85,7 +85,7 @@ def audible_parser(asin):
 		aud_json['product']['merchandising_summary']
 		)
 	metadata_dict['short_summary'] = (
-		html2text.html2text(aud_short_summary_json).replace("\n", " ")
+		html2text.html2text(aud_short_summary_json).replace("\n", " ").replace("\"", "'")
 		)
 
 	## Long summary
@@ -400,7 +400,7 @@ def m4b_data(input_data, metadata, output):
 		args.extend(processing_args)
 
 		if series:
-			args.append(f'--series \"{series}\"')
+			args.append(f"--series=\"{series}\"")
 
 		if in_ext == "m4b" or in_ext == "m4a":
 			logging.info(f"Multiple {in_ext} files, not converting")
@@ -461,7 +461,7 @@ def m4b_data(input_data, metadata, output):
 		args.extend(metadata_args)
 
 		if series:
-			args.append(f"--series \"{series}\"")
+			args.append(f"--series=\"{series}\"")
 
 		# make backup file
 		shutil.copy(
@@ -534,7 +534,7 @@ def m4b_data(input_data, metadata, output):
 		args.extend(processing_args)
 
 		if series:
-			args.append(f'--series \"{series}\"')
+			args.append(f"--series=\"{series}\"")
 
 		# m4b command with passed args
 		m4b_cmd = (

--- a/importer/merge_cli.py
+++ b/importer/merge_cli.py
@@ -387,15 +387,12 @@ def m4b_data(input_data, metadata, output):
 
 		dir_select_glob = Path(dir_select).glob('**/*')
 
-
-		first_file_index = 0
 		# Find first file with our extension, to check rates against
-		while True:
-			files_sorted = Path(sorted(dir_select_glob)[first_file_index])
-			if files_sorted.suffix == f".{in_ext}":
+		for file in sorted(dir_select_glob):
+			if file.suffix == f".{in_ext}":
+				first_file = file
 				break
-			first_file_index += 1
-		first_file = files_sorted
+
 		logging.debug(f"Got file to run mediainfo on: {first_file}")
 
 		## Mediainfo data

--- a/importer/views.py
+++ b/importer/views.py
@@ -16,7 +16,7 @@ import os
 
 # If using docker, default to /input folder, else $USER/input
 if Path('/input').is_dir():
-	rootdir = Path('/input')
+	rootdir = "/input"
 else:
 	rootdir = f"{str(Path.home())}/input"
 
@@ -261,10 +261,6 @@ def get_asin(request):
 	for key, value in dict1.items():
 		if key != "csrfmiddlewaretoken":
 			asin = value
-			asin_key = int(key[5:7])
-			input_data = get_directory(
-				f"{rootdir}/{request.session['input_dir'][asin_key]}"
-				)
 			# Check for validation errors
 			errors = Book.objects.book_asin_validator(asin)
 			if len(errors) > 0:
@@ -286,8 +282,8 @@ def get_asin(request):
 
 	for i in range(len(asin_arr)):
 		input_data = get_directory(
-				f"{rootdir}/{request.session['input_dir'][i]}"
-				)
+			Path(rootdir, request.session['input_dir'][i])
+		)
 		logger.info(
 			f"Making models and merging files for: "
 			f"{request.session['input_dir'][i]}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.24.0
 Django==2.2.4
 pathvalidate==2.4.1
 audible==0.5.4
+gunicorn==20.1.0


### PR DESCRIPTION
## Features:

- CLI: Add case to handle single mp3 inputs, closes https://github.com/djdembeck/bragibooks/issues/18
- CLI: Add case to handle single m4a files.
- Web: Switch to gunicorn for the webserver.
- CLI: Losslessly merge m4b files instead of converting them.
- CLI: Move processed folders to a `done` folder.

## Enhancements:

- Docker: Faster and smaller builds by reducing ffmpeg modules.
- Code optimizations.
- CLI: Set logging level of m4b-tool depending upon log_level
- CLI: Use m4b-tool verbose mode.

## Fixes:

- CLI: Fix some path `in_dir.parent` sections (this needs to be tested before merge).
- CLI: Don't blindly trust that input exists.
- CLI: Replace double quotes in metadata with single quotes to avoid command issues.
- CLI: Fix multi-disc.

## Documentation:

- Fix a few typos in the `docker run` command
- Change documentation for gunicorn commands
- Add CLI help output.