### PR TITLE
Fix button disabled bug #178

### DIFF
--- a/importer/templates/match.js
+++ b/importer/templates/match.js
@@ -169,6 +169,10 @@ async function searchAsin(title, author, keywords) {
     // Update the select for the calling custom search
     updateOptions(select, data)
 
+    // update cover image
+    const counter = select.id.split('-').pop();
+    updateImage(counter)
+
     // close the search panel
     closeSearchPanel();
 

--- a/importer/templates/match.js
+++ b/importer/templates/match.js
@@ -177,16 +177,19 @@ async function searchAsin(title, author, keywords) {
 }
 
 async function fetchOptions() {
-    document.querySelectorAll(".asin-select").forEach(async select => {
-        const url = "asin-search" + constructQueryParams(select.name.split('/').pop());
-        let data = await search(url);
+    const selects = document.querySelectorAll(".asin-select");
 
+    const searchPromises = Array.from(selects).map(async select => {
+        const url = "asin-search" + constructQueryParams(select.name.split('/').pop());
+
+        const data = await search(url);
         updateOptions(select, data);
 
         const counter = select.id.split('-').pop();
         updateImage(counter);
     });
 
+    await Promise.all(searchPromises);
     checkAllSelectsHaveValue();
 }
 


### PR DESCRIPTION
The forEach() method does not handle asynchronous functions properly. It is not designed to work with async/await syntax or handle promises returned by asynchronous operations. This caused the checkAllSelectsHaveValue call in the fetchOptions method to be called before all results from the async have been returned resulting in the button to be left as disabled. Updated the fetchOptions method to with for all the search results to come back before calling the checkAllSelectsHaveValue method.

Fix: submit button disabled even after all search books load 
Fix: cover image not updating after custom search

close #178 