### PR TITLE
Make completed_directory an optional setting to disable post-procesing move

### DIFF
--- a/importer/forms.py
+++ b/importer/forms.py
@@ -15,7 +15,7 @@ class SettingForm(forms.ModelForm):
         )
         labels = {
             'api_url': 'Custom API URL',
-            'completed_directory': 'Directory for copy of original input files',
+            'completed_directory': 'Directory for copy of original input files. Leave blank to disable moving.',
             'input_directory': 'Input directory path',
             'num_cpus': 'Number of CPUs to use (0 will use all available)',
             'output_directory': 'Output directory path',
@@ -23,7 +23,7 @@ class SettingForm(forms.ModelForm):
         }
         widgets = {
             'api_url': forms.URLInput(attrs={'class': 'input is-fullwidth'}),
-            'completed_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}),
+            'completed_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}, required=False),
             'input_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}),
             'num_cpus': forms.NumberInput(attrs={'class': 'input is-fullwidth'}),
             'output_directory': forms.TextInput(attrs={'class': 'input is-fullwidth'}),


### PR DESCRIPTION
Allow disabling the move after import. This will pair with a PR in m4b-merge which will not act on a blank junk_dir.

This is to stop bragibooks moving files from outside my download directory where they are managed by my download client.