### PR TITLE
Set permissions after DB initialise; make media permissions optional

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,9 +13,6 @@ chown -R appuser:appuser $APP_HOME
 
 echo "Starting with UID: $PUID, GID: $PGID"
 
-# Fix permissions
-chown -R "$PUID":"$PGID" /config /input /output
-
 until cd /home/app/web
 do
     echo "Waiting for server volume..."
@@ -28,6 +25,16 @@ do
     sleep 2
 done
 
+# Fix permissions
+#
+
+chown -R "$PUID":"$PGID" /config
+
+if [ ${FIX_MEDIA_PERMISSIONS:-true} = true ]; then
+    chown -R "$PUID":"$PGID" /input /output
+fi
+
+echo "Collecting static"
 python manage.py collectstatic --noinput
 
 # Start Celery Worker


### PR DESCRIPTION
This pull request fixes #254 by changing the order of `entrypoint.sh`

It also adds a new ENV: FIX_MEDIA_PERMISSIONS that, if set to false, stops bragi from trying to change the ownership on the /input and /output directories. Bragi isn’t the only app that is accessing those directories so I don’t want it to take ownership of everything. /config remains untouched as only bragi has access to that anyway.