### PR TITLE
feat: add loading states to import page

### DIFF
--- a/importer/templates/importer.html
+++ b/importer/templates/importer.html
@@ -85,7 +85,7 @@ to { transform: rotate(360deg); }
         <div id="loading-overlay" class="loading-overlay" role="status" aria-live="polite" aria-label="Loading">
             <h3 class="title is-4">Loading directories...</h3>
             <div class="loader">
-                <span class="button is-loading is-medium" aria-hidden="true">Loading</span>
+                <span class="button is-loading is-medium" aria-hidden="true"></span>
             </div>
         </div>
         <nav class="panel">

--- a/importer/templates/importer.html
+++ b/importer/templates/importer.html
@@ -43,11 +43,35 @@ cursor: default;
 .has-icons-right {
 position: relative;
 }
+
+.loading-overlay {
+position: absolute;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+background: rgba(255, 255, 255, 0.8);
+display: flex;
+flex-direction: column;
+justify-content: center;
+align-items: center;
+z-index: 100;
+}
+
+.column {
+position: relative;
+}
 {% endblock %}
 {% load directory_explorer_tags %}
 {% block content %}
 <div class="columns">
     <div class="column">
+        <div id="loading-overlay" class="loading-overlay" role="status" aria-live="polite" aria-label="Loading">
+            <h3 class="title is-4">Loading directories...</h3>
+            <div class="loader">
+                <button class="button is-loading is-medium" aria-hidden="true">Loading</button>
+            </div>
+        </div>
         <nav class="panel">
             <p class="panel-heading">
                 Choose Files or Directories to process

--- a/importer/templates/importer.html
+++ b/importer/templates/importer.html
@@ -61,6 +61,22 @@ z-index: 100;
 .column {
 position: relative;
 }
+
+.folder-loading {
+display: inline-block;
+width: 1em;
+height: 1em;
+border: 2px solid #dbdbdb;
+border-top-color: #3273dc;
+border-radius: 50%;
+animation: folder-loading-spin 0.75s linear infinite;
+margin-left: 0.5em;
+vertical-align: middle;
+}
+
+@keyframes folder-loading-spin {
+to { transform: rotate(360deg); }
+}
 {% endblock %}
 {% load directory_explorer_tags %}
 {% block content %}
@@ -69,7 +85,7 @@ position: relative;
         <div id="loading-overlay" class="loading-overlay" role="status" aria-live="polite" aria-label="Loading">
             <h3 class="title is-4">Loading directories...</h3>
             <div class="loader">
-                <button class="button is-loading is-medium" aria-hidden="true">Loading</button>
+                <span class="button is-loading is-medium" aria-hidden="true">Loading</span>
             </div>
         </div>
         <nav class="panel">

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -1,14 +1,11 @@
 function expandFolder(folderId) {
-    // Select the arrow element
-    const arrow = document.querySelector(`.folder[id^='${folderId}'] .arrow i`);
-
-    // Toggle the rotation class on the arrow element
-    arrow.classList.toggle('fa-rotate-90');
-
-    // Select all items in the folder
+    const folderElement = document.querySelector(`.folder[id^='${folderId}']`);
+    const arrow = folderElement.querySelector('.arrow i');
+    const isExpanded = arrow.classList.contains('fa-rotate-90');
     const items = document.querySelectorAll(`.panel-block[folder-id^='${folderId}']`);
 
-    // Toggle the display style of each item
+    arrow.classList.toggle('fa-rotate-90');
+
     items.forEach(item => {
         item.style.display = item.style.display === 'none' ? '' : 'none';
     });
@@ -88,7 +85,7 @@ searchInput.addEventListener('input', () => {
             }
         });
     } else {
-        resetPanel()
+        resetPanel();
     }
 });
 
@@ -106,5 +103,12 @@ selectAllCheckbox.addEventListener("change", function () {
 const clearSearchButton = document.querySelector('.clear-search');
 clearSearchButton.addEventListener('click', () => {
     searchInput.value = '';
-    resetPanel()
+    resetPanel();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const loadingOverlay = document.getElementById('loading-overlay');
+    if (loadingOverlay) {
+        loadingOverlay.style.display = 'none';
+    }
 });

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -156,5 +156,5 @@ if (typeof document !== 'undefined') {
 
 // Export for testing (works in Node.js module context)
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { hideLoadingOverlay };
+    module.exports = { hideLoadingOverlay, expandFolder, initArrowListeners, initSearch, fuzzyMatch, resetPanel };
 }

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -1,6 +1,16 @@
 function expandFolder(folderId) {
     const folderElement = document.querySelector(`.folder[id^='${folderId}']`);
+    if (!folderElement) return;
     const arrow = folderElement.querySelector('.arrow i');
+    if (!arrow) return;
+
+    // Create and append loading spinner synchronously
+    // This gives the browser a paint opportunity before expansion
+    const loader = document.createElement('span');
+    loader.className = 'folder-loading';
+    folderElement.appendChild(loader);
+
+    // Perform expansion synchronously (fast operation)
     const isExpanded = arrow.classList.contains('fa-rotate-90');
     const items = document.querySelectorAll(`.panel-block[folder-id^='${folderId}']`);
 
@@ -9,15 +19,23 @@ function expandFolder(folderId) {
     items.forEach(item => {
         item.style.display = item.style.display === 'none' ? '' : 'none';
     });
+
+    // Defer spinner removal to next frame so user sees it briefly
+    requestAnimationFrame(() => {
+        const spinner = folderElement.querySelector('.folder-loading');
+        if (spinner) spinner.remove();
+    });
 }
 
-const arrows = document.querySelectorAll(".arrow i");
-arrows.forEach(arrow => {
-    arrow.addEventListener("click", (event) => {
-        event.preventDefault();
-        expandFolder(arrow.id)
+function initArrowListeners() {
+    const arrows = document.querySelectorAll(".arrow i");
+    arrows.forEach(arrow => {
+        arrow.addEventListener("click", (event) => {
+            event.preventDefault();
+            expandFolder(arrow.id);
+        });
     });
-});
+}
 
 function fuzzyMatch(needle, haystack) {
     let hlen = haystack.length;
@@ -42,6 +60,9 @@ function fuzzyMatch(needle, haystack) {
 
 function resetPanel() {
     // reset the file explorer to its base config
+    const panelBlock = document.querySelector('.panel-block-container');
+    if (!panelBlock) return;
+
     const depth0 = panelBlock.querySelectorAll('label.panel-block[folder-id=""]');
     const everythingElse = panelBlock.querySelectorAll('label.panel-block:not([folder-id=""])');
 
@@ -62,53 +83,78 @@ function resetPanel() {
     });
 }
 
-// Get the search input and panel elements
-const searchInput = document.getElementById('search-input');
-const panelBlock = document.querySelector('.panel-block-container');
+function initSearch() {
+    // Get the search input and panel elements
+    const searchInput = document.getElementById('search-input');
+    const panelBlock = document.querySelector('.panel-block-container');
 
-// Add an input event listener to the search input
-searchInput.addEventListener('input', () => {
-    // Get the search query
-    let query = searchInput.value.toLowerCase();
+    if (!searchInput || !panelBlock) return;
 
-    if (query) {
-        // Loop through each label in the panel
-        panelBlock.querySelectorAll('label').forEach(label => {
-            // Get the label text
-            const labelText = label.textContent.toLowerCase().trim();
+    // Add an input event listener to the search input
+    searchInput.addEventListener('input', () => {
+        // Get the search query
+        let query = searchInput.value.toLowerCase();
 
-            // Show or hide the label based on whether the query matches the label text
-            if (fuzzyMatch(query, labelText)) {
-                label.style.display = '';
-            } else {
-                label.style.display = 'none';
-            }
-        });
-    } else {
-        resetPanel();
-    }
-});
+        if (query) {
+            // Loop through each label in the panel
+            panelBlock.querySelectorAll('label').forEach(label => {
+                // Get the label text
+                const labelText = label.textContent.toLowerCase().trim();
 
-
-
-// add action to make the select all checkbox select/deselect all top level objects
-const selectAllCheckbox = document.getElementById("select-all-checkbox");
-const checkboxes = document.querySelectorAll('.panel-block-container label[folder-id=""] input[type="checkbox"]');
-selectAllCheckbox.addEventListener("change", function () {
-    checkboxes.forEach(function (checkbox) {
-        checkbox.checked = selectAllCheckbox.checked;
+                // Show or hide the label based on whether the query matches the label text
+                if (fuzzyMatch(query, labelText)) {
+                    label.style.display = '';
+                } else {
+                    label.style.display = 'none';
+                }
+            });
+        } else {
+            resetPanel();
+        }
     });
-});
 
-const clearSearchButton = document.querySelector('.clear-search');
-clearSearchButton.addEventListener('click', () => {
-    searchInput.value = '';
-    resetPanel();
-});
+    // add action to make the select all checkbox select/deselect all top level objects
+    const selectAllCheckbox = document.getElementById("select-all-checkbox");
+    const checkboxes = document.querySelectorAll('.panel-block-container label[folder-id=""] input[type="checkbox"]');
+    if (selectAllCheckbox) {
+        selectAllCheckbox.addEventListener("change", function () {
+            checkboxes.forEach(function (checkbox) {
+                checkbox.checked = selectAllCheckbox.checked;
+            });
+        });
+    }
 
-document.addEventListener('DOMContentLoaded', () => {
-    const loadingOverlay = document.getElementById('loading-overlay');
-    if (loadingOverlay) {
+    const clearSearchButton = document.querySelector('.clear-search');
+    if (clearSearchButton) {
+        clearSearchButton.addEventListener('click', () => {
+            searchInput.value = '';
+            resetPanel();
+        });
+    }
+}
+
+/**
+ * Hides the loading overlay when called.
+ * Exported for testing purposes.
+ * @param {Document} doc - The document object (defaults to global document)
+ */
+function hideLoadingOverlay(doc = document) {
+    const loadingOverlay = doc.getElementById('loading-overlay');
+    if (loadingOverlay && loadingOverlay.style) {
         loadingOverlay.style.display = 'none';
     }
-});
+}
+
+// Initialize on DOMContentLoaded for browser usage
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        initArrowListeners();
+        initSearch();
+        hideLoadingOverlay();
+    });
+}
+
+// Export for testing (works in Node.js module context)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { hideLoadingOverlay };
+}

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -7,12 +7,26 @@ class MockElement {
         this.tagName = tagName;
         this.style = {};
         this.children = [];
-        this.classList = new MockClassList();
+        this.classList = new MockClassList(this);
         this.eventListeners = new Map();
         this.textContent = '';
         this.attributes = new Map();
         this.parentElement = null;
         this.id = '';
+        this._className = '';
+    }
+
+    set className(value) {
+        this._className = value;
+        // Sync classList with className
+        this.classList.classes.clear();
+        value.split(/\s+/).forEach(cls => {
+            if (cls) this.classList.classes.add(cls);
+        });
+    }
+
+    get className() {
+        return this._className;
     }
 
     matches(selector) {
@@ -123,14 +137,27 @@ class MockElement {
 }
 
 class MockClassList {
-    constructor() { this.classes = new Set(); }
+    constructor(parent) {
+        this.parent = parent;
+        this.classes = new Set();
+    }
     contains(className) { return this.classes.has(className); }
-    add(className) { this.classes.add(className); }
-    remove(className) { this.classes.delete(className); }
-    toggle(className) {
-        if (this.classes.has(className)) { this.classes.delete(className); return false; }
+    add(className) {
         this.classes.add(className);
-        return true;
+        if (this.parent) this.parent._className = Array.from(this.classes).join(' ');
+    }
+    remove(className) {
+        this.classes.delete(className);
+        if (this.parent) this.parent._className = Array.from(this.classes).join(' ');
+    }
+    toggle(className) {
+        if (this.classes.has(className)) {
+            this.classes.delete(className);
+        } else {
+            this.classes.add(className);
+        }
+        if (this.parent) this.parent._className = Array.from(this.classes).join(' ');
+        return this.classes.has(className);
     }
 }
 
@@ -237,7 +264,7 @@ describe('hideLoadingOverlay', () => {
 });
 
 describe('expandFolder', () => {
-    it('should create and remove spinner element when expanding a collapsed folder', () => {
+    it('should create and remove spinner element when expanding a collapsed folder', async () => {
         const mockDoc = new MockDocument();
         const folder = new MockElement('div');
         folder.classList.add('folder');
@@ -258,12 +285,26 @@ describe('expandFolder', () => {
         mockDoc.addMockElement(item);
 
         const originalDoc = global.document;
-        global.document = mockDoc;
-        expandFolder('folder-test');
-        global.document = originalDoc;
+        try {
+            global.document = mockDoc;
+            expandFolder('folder-test');
 
-        assert.strictEqual(item.style.display, '', 'Item should be visible after expansion');
-        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), true, 'Arrow should have fa-rotate-90 class');
+            // Assert spinner was created immediately
+            const spinnerCreated = folder.children.some(child => child.classList && child.classList.contains('folder-loading'));
+            assert.strictEqual(spinnerCreated, true, 'Spinner element should be created immediately after expandFolder call');
+
+            // Flush the requestAnimationFrame callback (mocked as setTimeout(callback, 0))
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            // Assert spinner was removed after async operation
+            const spinnerRemoved = !folder.children.some(child => child.classList && child.classList.contains('folder-loading'));
+            assert.strictEqual(spinnerRemoved, true, 'Spinner element should be removed after requestAnimationFrame callback');
+
+            assert.strictEqual(item.style.display, '', 'Item should be visible after expansion');
+            assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), true, 'Arrow should have fa-rotate-90 class');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle already-expanded folders by collapsing them', () => {
@@ -329,8 +370,11 @@ describe('initArrowListeners', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initArrowListeners();
-        global.document = originalDoc;
+        try {
+            initArrowListeners();
+        } finally {
+            global.document = originalDoc;
+        }
 
         assert.strictEqual(arrowIcon.eventListeners.has('click'), true, 'Click listener should be attached');
     });
@@ -359,14 +403,17 @@ describe('initArrowListeners', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initArrowListeners();
+        try {
+            initArrowListeners();
 
-        const clickEvent = { preventDefault: () => {} };
-        const handlers = arrowIcon.eventListeners.get('click');
-        assert.ok(handlers && handlers.length > 0, 'Click handlers should exist');
+            const clickEvent = { preventDefault: () => {} };
+            const handlers = arrowIcon.eventListeners.get('click');
+            assert.ok(handlers && handlers.length > 0, 'Click handlers should exist');
 
-        handlers[0](clickEvent);
-        global.document = originalDoc;
+            handlers[0](clickEvent);
+        } finally {
+            global.document = originalDoc;
+        }
 
         assert.strictEqual(item.style.display, '', 'Item should be visible after click');
     });

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -328,20 +328,26 @@ describe('expandFolder', () => {
         mockDoc.addMockElement(item);
 
         const originalDoc = global.document;
-        global.document = mockDoc;
-        expandFolder('folder-test');
-        global.document = originalDoc;
+        try {
+            global.document = mockDoc;
+            expandFolder('folder-test');
 
-        assert.strictEqual(item.style.display, 'none', 'Item should be hidden after collapse');
-        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'Arrow should not have fa-rotate-90 class');
+            assert.strictEqual(item.style.display, 'none', 'Item should be hidden after collapse');
+            assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'Arrow should not have fa-rotate-90 class');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle missing folder element gracefully', () => {
         const mockDoc = new MockDocument();
         const originalDoc = global.document;
-        global.document = mockDoc;
-        assert.doesNotThrow(() => expandFolder('non-existent-folder'));
-        global.document = originalDoc;
+        try {
+            global.document = mockDoc;
+            assert.doesNotThrow(() => expandFolder('non-existent-folder'));
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle missing arrow element gracefully', () => {
@@ -352,9 +358,12 @@ describe('expandFolder', () => {
         mockDoc.addMockElement(folder);
 
         const originalDoc = global.document;
-        global.document = mockDoc;
-        assert.doesNotThrow(() => expandFolder('folder-test'));
-        global.document = originalDoc;
+        try {
+            global.document = mockDoc;
+            assert.doesNotThrow(() => expandFolder('folder-test'));
+        } finally {
+            global.document = originalDoc;
+        }
     });
 });
 
@@ -369,8 +378,8 @@ describe('initArrowListeners', () => {
         mockDoc.addMockElement(arrowDiv);
 
         const originalDoc = global.document;
-        global.document = mockDoc;
         try {
+            global.document = mockDoc;
             initArrowListeners();
         } finally {
             global.document = originalDoc;
@@ -402,8 +411,8 @@ describe('initArrowListeners', () => {
         mockDoc.addMockElement(item);
 
         const originalDoc = global.document;
-        global.document = mockDoc;
         try {
+            global.document = mockDoc;
             initArrowListeners();
 
             const clickEvent = { preventDefault: () => {} };
@@ -476,10 +485,12 @@ describe('resetPanel', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        resetPanel();
-        global.document = originalDoc;
-
-        assert.strictEqual(depth0Item.style.display, '', 'Depth-0 item should be visible');
+        try {
+            resetPanel();
+            assert.strictEqual(depth0Item.style.display, '', 'Depth-0 item should be visible');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should hide non-depth-0 items', () => {
@@ -497,10 +508,12 @@ describe('resetPanel', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        resetPanel();
-        global.document = originalDoc;
-
-        assert.strictEqual(depthItem.style.display, 'none', 'Non-depth-0 item should be hidden');
+        try {
+            resetPanel();
+            assert.strictEqual(depthItem.style.display, 'none', 'Non-depth-0 item should be hidden');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should remove fa-rotate-90 class from arrows', () => {
@@ -518,18 +531,23 @@ describe('resetPanel', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        resetPanel();
-        global.document = originalDoc;
-
-        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'fa-rotate-90 class should be removed');
+        try {
+            resetPanel();
+            assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'fa-rotate-90 class should be removed');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle missing panel-block-container gracefully', () => {
         const mockDoc = new MockDocument();
         const originalDoc = global.document;
         global.document = mockDoc;
-        assert.doesNotThrow(() => resetPanel());
-        global.document = originalDoc;
+        try {
+            assert.doesNotThrow(() => resetPanel());
+        } finally {
+            global.document = originalDoc;
+        }
     });
 });
 
@@ -546,10 +564,12 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initSearch();
-        global.document = originalDoc;
-
-        assert.strictEqual(searchInput.eventListeners.has('input'), true, 'Input listener should be attached');
+        try {
+            initSearch();
+            assert.strictEqual(searchInput.eventListeners.has('input'), true, 'Input listener should be attached');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should update DOM visibility based on fuzzy matching', () => {
@@ -574,16 +594,18 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initSearch();
+        try {
+            initSearch();
 
-        const handlers = searchInput.eventListeners.get('input');
-        assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
-        handlers[0]();
+            const handlers = searchInput.eventListeners.get('input');
+            assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
+            handlers[0]();
 
-        global.document = originalDoc;
-
-        assert.strictEqual(label1.style.display, '', 'Matching label should be visible');
-        assert.strictEqual(label2.style.display, 'none', 'Non-matching label should be hidden');
+            assert.strictEqual(label1.style.display, '', 'Matching label should be visible');
+            assert.strictEqual(label2.style.display, 'none', 'Non-matching label should be hidden');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should call resetPanel when search query is empty', () => {
@@ -612,16 +634,18 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initSearch();
+        try {
+            initSearch();
 
-        const handlers = searchInput.eventListeners.get('input');
-        assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
-        handlers[0]();
+            const handlers = searchInput.eventListeners.get('input');
+            assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
+            handlers[0]();
 
-        global.document = originalDoc;
-
-        assert.strictEqual(depth0Item.style.display, '', 'resetPanel should show depth-0 items');
-        assert.strictEqual(nonDepthItem.style.display, 'none', 'resetPanel should hide non-depth-0 items');
+            assert.strictEqual(depth0Item.style.display, '', 'resetPanel should show depth-0 items');
+            assert.strictEqual(nonDepthItem.style.display, 'none', 'resetPanel should hide non-depth-0 items');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should attach clear search button listener if present', () => {
@@ -640,10 +664,12 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        initSearch();
-        global.document = originalDoc;
-
-        assert.strictEqual(clearButton.eventListeners.has('click'), true, 'Clear button should have click listener');
+        try {
+            initSearch();
+            assert.strictEqual(clearButton.eventListeners.has('click'), true, 'Clear button should have click listener');
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle missing search input gracefully', () => {
@@ -654,8 +680,11 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        assert.doesNotThrow(() => initSearch());
-        global.document = originalDoc;
+        try {
+            assert.doesNotThrow(() => initSearch());
+        } finally {
+            global.document = originalDoc;
+        }
     });
 
     it('should handle missing panel-block-container gracefully', () => {
@@ -666,7 +695,10 @@ describe('initSearch', () => {
 
         const originalDoc = global.document;
         global.document = mockDoc;
-        assert.doesNotThrow(() => initSearch());
-        global.document = originalDoc;
+        try {
+            assert.doesNotThrow(() => initSearch());
+        } finally {
+            global.document = originalDoc;
+        }
     });
 });

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -1,0 +1,56 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+// Mock DOM implementation
+class MockElement {
+    constructor() {
+        this.style = {};
+    }
+}
+
+class MockDocument {
+    constructor() {
+        this.elements = new Map();
+    }
+
+    getElementById(id) {
+        return this.elements.get(id) || null;
+    }
+
+    setElement(id, element) {
+        this.elements.set(id, element);
+    }
+}
+
+describe('hideLoadingOverlay', () => {
+    it('should set loading-overlay display to none when element exists', () => {
+        const { hideLoadingOverlay } = require('./importer.js');
+        const mockDoc = new MockDocument();
+        const loadingOverlay = new MockElement();
+        mockDoc.setElement('loading-overlay', loadingOverlay);
+
+        hideLoadingOverlay(mockDoc);
+
+        assert.strictEqual(loadingOverlay.style.display, 'none');
+    });
+
+    it('should not throw error when loading-overlay element does not exist', () => {
+        const { hideLoadingOverlay } = require('./importer.js');
+        const mockDoc = new MockDocument();
+
+        assert.doesNotThrow(() => {
+            hideLoadingOverlay(mockDoc);
+        });
+    });
+
+    it('should not throw error when element has no style property', () => {
+        const { hideLoadingOverlay } = require('./importer.js');
+        const mockDoc = new MockDocument();
+        const loadingOverlay = {};
+        mockDoc.setElement('loading-overlay', loadingOverlay);
+
+        assert.doesNotThrow(() => {
+            hideLoadingOverlay(mockDoc);
+        });
+    });
+});

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -24,7 +24,8 @@ class MockElement {
         if (selector.startsWith('#')) {
             return this.attributes.get('id') === selector.slice(1);
         }
-        return true;
+        console.warn('Unsupported selector pattern:', selector);
+        return false;
     }
 
     querySelector(selector) {

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -1,6 +1,10 @@
-const { describe, it } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert');
 const { hideLoadingOverlay, expandFolder, initArrowListeners, initSearch, fuzzyMatch, resetPanel } = require('./importer.js');
+
+// Save the original requestAnimationFrame before any reassignment
+// Note: requestAnimationFrame is undefined in Node.js by default
+const _origRequestAnimationFrame = global.requestAnimationFrame;
 
 class MockElement {
     constructor(tagName = 'div') {
@@ -240,7 +244,14 @@ class MockDocument {
     createElement(tagName) { return new MockElement(tagName); }
 }
 
-global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+// Use before/after hooks to manage the override
+before(() => {
+    global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+});
+
+after(() => {
+    global.requestAnimationFrame = _origRequestAnimationFrame;
+});
 
 describe('hideLoadingOverlay', () => {
     it('should set loading-overlay display to none when element exists', () => {

--- a/importer/templates/importer.test.js
+++ b/importer/templates/importer.test.js
@@ -1,56 +1,624 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
+const { hideLoadingOverlay, expandFolder, initArrowListeners, initSearch, fuzzyMatch, resetPanel } = require('./importer.js');
 
-// Mock DOM implementation
 class MockElement {
-    constructor() {
+    constructor(tagName = 'div') {
+        this.tagName = tagName;
         this.style = {};
+        this.children = [];
+        this.classList = new MockClassList();
+        this.eventListeners = new Map();
+        this.textContent = '';
+        this.attributes = new Map();
+        this.parentElement = null;
+        this.id = '';
+    }
+
+    matches(selector) {
+        if (selector.startsWith('.')) {
+            const parts = selector.slice(1).split(/[\s\[]/);
+            return this.classList.contains(parts[0]);
+        }
+        if (selector === this.tagName) return true;
+        if (selector.startsWith('#')) {
+            return this.attributes.get('id') === selector.slice(1);
+        }
+        return true;
+    }
+
+    querySelector(selector) {
+        if (selector === '.arrow i') {
+            for (const child of this.children) {
+                if (child.classList && child.classList.contains('arrow')) {
+                    for (const subChild of child.children) {
+                        if (subChild.tagName === 'i') return subChild;
+                    }
+                }
+            }
+            return null;
+        }
+        if (selector.startsWith('.')) {
+            const className = selector.slice(1);
+            for (const child of this.children) {
+                if (child.classList && child.classList.contains(className)) return child;
+            }
+        }
+        return null;
+    }
+
+    querySelectorAll(selector) {
+        const results = [];
+        if (selector === 'label.panel-block[folder-id=""]') {
+            for (const child of this.children) {
+                if (child.tagName === 'label' && child.classList && child.classList.contains('panel-block')) {
+                    const attr = child.attributes.get('folder-id');
+                    if (attr === '') results.push(child);
+                }
+            }
+            return results;
+        }
+        if (selector === 'label.panel-block:not([folder-id=""])') {
+            for (const child of this.children) {
+                if (child.tagName === 'label' && child.classList && child.classList.contains('panel-block')) {
+                    const attr = child.attributes.get('folder-id');
+                    if (attr && attr !== '') results.push(child);
+                }
+            }
+            return results;
+        }
+        if (selector.includes('[folder-id^=')) {
+            const match = selector.match(/folder-id\^='([^']+)'/);
+            if (match) {
+                const folderId = match[1];
+                for (const child of this.children) {
+                    if (child.classList && child.classList.contains('panel-block')) {
+                        const attr = child.attributes.get('folder-id');
+                        if (attr && attr.startsWith(folderId)) results.push(child);
+                    }
+                }
+            }
+            return results;
+        }
+        if (selector === '.arrow i') {
+            for (const child of this.children) {
+                if (child.classList && child.classList.contains('arrow')) {
+                    for (const subChild of child.children) {
+                        if (subChild.tagName === 'i') results.push(subChild);
+                    }
+                }
+            }
+            return results;
+        }
+        if (selector === 'label') {
+            for (const child of this.children) {
+                if (child.tagName === 'label') results.push(child);
+            }
+            return results;
+        }
+        return results;
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        child.parentElement = this;
+        return child;
+    }
+
+    remove() {
+        if (this.parentElement) {
+            const index = this.parentElement.children.indexOf(this);
+            if (index > -1) this.parentElement.children.splice(index, 1);
+        }
+    }
+
+    addEventListener(event, handler) {
+        if (!this.eventListeners.has(event)) this.eventListeners.set(event, []);
+        this.eventListeners.get(event).push(handler);
+    }
+
+    getAttribute(name) { return this.attributes.get(name) || null; }
+    setAttribute(name, value) { this.attributes.set(name, value); }
+}
+
+class MockClassList {
+    constructor() { this.classes = new Set(); }
+    contains(className) { return this.classes.has(className); }
+    add(className) { this.classes.add(className); }
+    remove(className) { this.classes.delete(className); }
+    toggle(className) {
+        if (this.classes.has(className)) { this.classes.delete(className); return false; }
+        this.classes.add(className);
+        return true;
     }
 }
 
 class MockDocument {
     constructor() {
         this.elements = new Map();
+        this._mockElements = [];
     }
 
-    getElementById(id) {
-        return this.elements.get(id) || null;
+    getElementById(id) { return this.elements.get(id) || null; }
+    setElement(id, element) { this.elements.set(id, element); }
+    addMockElement(element) { this._mockElements.push(element); }
+
+    querySelector(selector) {
+        const folderMatch = selector.match(/\.folder\[id\^=['"]([^'"]+)['"]\]/);
+        if (folderMatch) {
+            const folderId = folderMatch[1];
+            for (const el of this._mockElements) {
+                if (el.classList.contains('folder')) {
+                    const id = el.getAttribute('id');
+                    if (id && id.startsWith(folderId)) return el;
+                }
+            }
+            return null;
+        }
+        if (selector === '.panel-block-container') {
+            for (const el of this._mockElements) {
+                if (el.classList.contains('panel-block-container')) return el;
+            }
+            return null;
+        }
+        if (selector === '.arrow i') {
+            for (const el of this._mockElements) {
+                if (el.classList.contains('arrow')) {
+                    for (const child of el.children) {
+                        if (child.tagName === 'i') return child;
+                    }
+                }
+            }
+            return null;
+        }
+        if (selector === '#search-input') {
+            return this.getElementById('search-input');
+        }
+        if (selector === '.clear-search') {
+            for (const el of this._mockElements) {
+                if (el.classList.contains('clear-search')) return el;
+            }
+            return null;
+        }
+        return null;
     }
 
-    setElement(id, element) {
-        this.elements.set(id, element);
+    querySelectorAll(selector) {
+        const results = [];
+        if (selector === '.arrow i') {
+            for (const el of this._mockElements) {
+                if (el.classList.contains('arrow')) {
+                    for (const child of el.children) {
+                        if (child.tagName === 'i') results.push(child);
+                    }
+                }
+            }
+            return results;
+        }
+        const panelBlockMatch = selector.match(/\.panel-block\[folder-id\^=['"]([^'"]+)['"]\]/);
+        if (panelBlockMatch) {
+            const folderId = panelBlockMatch[1];
+            for (const el of this._mockElements) {
+                if (el.classList.contains('panel-block')) {
+                    const fid = el.getAttribute('folder-id');
+                    if (fid && fid.startsWith(folderId)) results.push(el);
+                }
+            }
+            return results;
+        }
+        return results;
     }
+
+    createElement(tagName) { return new MockElement(tagName); }
 }
+
+global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
 
 describe('hideLoadingOverlay', () => {
     it('should set loading-overlay display to none when element exists', () => {
-        const { hideLoadingOverlay } = require('./importer.js');
         const mockDoc = new MockDocument();
         const loadingOverlay = new MockElement();
         mockDoc.setElement('loading-overlay', loadingOverlay);
-
         hideLoadingOverlay(mockDoc);
-
         assert.strictEqual(loadingOverlay.style.display, 'none');
     });
 
     it('should not throw error when loading-overlay element does not exist', () => {
-        const { hideLoadingOverlay } = require('./importer.js');
         const mockDoc = new MockDocument();
-
-        assert.doesNotThrow(() => {
-            hideLoadingOverlay(mockDoc);
-        });
+        assert.doesNotThrow(() => hideLoadingOverlay(mockDoc));
     });
 
     it('should not throw error when element has no style property', () => {
-        const { hideLoadingOverlay } = require('./importer.js');
         const mockDoc = new MockDocument();
-        const loadingOverlay = {};
-        mockDoc.setElement('loading-overlay', loadingOverlay);
+        mockDoc.setElement('loading-overlay', {});
+        assert.doesNotThrow(() => hideLoadingOverlay(mockDoc));
+    });
+});
 
-        assert.doesNotThrow(() => {
-            hideLoadingOverlay(mockDoc);
-        });
+describe('expandFolder', () => {
+    it('should create and remove spinner element when expanding a collapsed folder', () => {
+        const mockDoc = new MockDocument();
+        const folder = new MockElement('div');
+        folder.classList.add('folder');
+        folder.setAttribute('id', 'folder-test');
+
+        const arrowDiv = new MockElement('div');
+        arrowDiv.classList.add('arrow');
+        const arrowIcon = new MockElement('i');
+        arrowDiv.children.push(arrowIcon);
+        folder.children.push(arrowDiv);
+
+        const item = new MockElement('label');
+        item.classList.add('panel-block');
+        item.setAttribute('folder-id', 'folder-test');
+        item.style.display = 'none';
+
+        mockDoc.addMockElement(folder);
+        mockDoc.addMockElement(item);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        expandFolder('folder-test');
+        global.document = originalDoc;
+
+        assert.strictEqual(item.style.display, '', 'Item should be visible after expansion');
+        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), true, 'Arrow should have fa-rotate-90 class');
+    });
+
+    it('should handle already-expanded folders by collapsing them', () => {
+        const mockDoc = new MockDocument();
+        const folder = new MockElement('div');
+        folder.classList.add('folder');
+        folder.setAttribute('id', 'folder-test');
+
+        const arrowDiv = new MockElement('div');
+        arrowDiv.classList.add('arrow');
+        const arrowIcon = new MockElement('i');
+        arrowIcon.classList.add('fa-rotate-90');
+        arrowDiv.children.push(arrowIcon);
+        folder.children.push(arrowDiv);
+
+        const item = new MockElement('label');
+        item.classList.add('panel-block');
+        item.setAttribute('folder-id', 'folder-test');
+
+        mockDoc.addMockElement(folder);
+        mockDoc.addMockElement(item);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        expandFolder('folder-test');
+        global.document = originalDoc;
+
+        assert.strictEqual(item.style.display, 'none', 'Item should be hidden after collapse');
+        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'Arrow should not have fa-rotate-90 class');
+    });
+
+    it('should handle missing folder element gracefully', () => {
+        const mockDoc = new MockDocument();
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        assert.doesNotThrow(() => expandFolder('non-existent-folder'));
+        global.document = originalDoc;
+    });
+
+    it('should handle missing arrow element gracefully', () => {
+        const mockDoc = new MockDocument();
+        const folder = new MockElement('div');
+        folder.classList.add('folder');
+        folder.setAttribute('id', 'folder-test');
+        mockDoc.addMockElement(folder);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        assert.doesNotThrow(() => expandFolder('folder-test'));
+        global.document = originalDoc;
+    });
+});
+
+describe('initArrowListeners', () => {
+    it('should attach click event listeners to arrow elements', () => {
+        const mockDoc = new MockDocument();
+        const arrowDiv = new MockElement('div');
+        arrowDiv.classList.add('arrow');
+        const arrowIcon = new MockElement('i');
+        arrowIcon.id = 'arrow-1';
+        arrowDiv.children.push(arrowIcon);
+        mockDoc.addMockElement(arrowDiv);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initArrowListeners();
+        global.document = originalDoc;
+
+        assert.strictEqual(arrowIcon.eventListeners.has('click'), true, 'Click listener should be attached');
+    });
+
+    it('should toggle expanded state when arrow is clicked', () => {
+        const mockDoc = new MockDocument();
+        const folder = new MockElement('div');
+        folder.classList.add('folder');
+        folder.setAttribute('id', 'folder-test');
+
+        const arrowDiv = new MockElement('div');
+        arrowDiv.classList.add('arrow');
+        const arrowIcon = new MockElement('i');
+        arrowIcon.id = 'folder-test';
+        arrowDiv.children.push(arrowIcon);
+        folder.children.push(arrowDiv);
+
+        const item = new MockElement('label');
+        item.classList.add('panel-block');
+        item.setAttribute('folder-id', 'folder-test');
+        item.style.display = 'none';
+
+        mockDoc.addMockElement(folder);
+        mockDoc.addMockElement(arrowDiv);
+        mockDoc.addMockElement(item);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initArrowListeners();
+
+        const clickEvent = { preventDefault: () => {} };
+        const handlers = arrowIcon.eventListeners.get('click');
+        assert.ok(handlers && handlers.length > 0, 'Click handlers should exist');
+
+        handlers[0](clickEvent);
+        global.document = originalDoc;
+
+        assert.strictEqual(item.style.display, '', 'Item should be visible after click');
+    });
+});
+
+describe('fuzzyMatch', () => {
+    it('should return true for exact match', () => {
+        assert.strictEqual(fuzzyMatch('hello', 'hello'), true);
+        assert.strictEqual(fuzzyMatch('test', 'test'), true);
+    });
+
+    it('should return true for fuzzy match with characters in order', () => {
+        assert.strictEqual(fuzzyMatch('hl', 'hello'), true);
+        assert.strictEqual(fuzzyMatch('tst', 'test'), true);
+        assert.strictEqual(fuzzyMatch('abc', 'aabbcc'), true);
+        assert.strictEqual(fuzzyMatch('xyz', 'xaybzc'), true);
+    });
+
+    it('should return false when needle is not in haystack', () => {
+        assert.strictEqual(fuzzyMatch('xyz', 'hello'), false);
+        assert.strictEqual(fuzzyMatch('abc', 'def'), false);
+        assert.strictEqual(fuzzyMatch('world', 'hello'), false);
+    });
+
+    it('should return false when needle is longer than haystack', () => {
+        assert.strictEqual(fuzzyMatch('hello', 'hi'), false);
+        assert.strictEqual(fuzzyMatch('world', 'wor'), false);
+        assert.strictEqual(fuzzyMatch('abcdef', 'abc'), false);
+    });
+
+    it('should return false when characters are out of order', () => {
+        assert.strictEqual(fuzzyMatch('cba', 'abc'), false);
+        assert.strictEqual(fuzzyMatch('olleh', 'hello'), false);
+    });
+
+    it('should handle empty strings', () => {
+        assert.strictEqual(fuzzyMatch('', 'hello'), true);
+        assert.strictEqual(fuzzyMatch('', ''), true);
+    });
+
+    it('should handle case sensitivity correctly', () => {
+        assert.strictEqual(fuzzyMatch('HELLO', 'hello'), false);
+        assert.strictEqual(fuzzyMatch('Hello', 'hello'), false);
+    });
+});
+
+describe('resetPanel', () => {
+    it('should show all depth-0 items', () => {
+        const mockDoc = new MockDocument();
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+
+        const depth0Item = new MockElement('label');
+        depth0Item.classList.add('panel-block');
+        depth0Item.setAttribute('folder-id', '');
+        depth0Item.style.display = 'none';
+        container.children.push(depth0Item);
+
+        mockDoc.addMockElement(container);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        resetPanel();
+        global.document = originalDoc;
+
+        assert.strictEqual(depth0Item.style.display, '', 'Depth-0 item should be visible');
+    });
+
+    it('should hide non-depth-0 items', () => {
+        const mockDoc = new MockDocument();
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+
+        const depthItem = new MockElement('label');
+        depthItem.classList.add('panel-block');
+        depthItem.setAttribute('folder-id', 'folder-1');
+        depthItem.style.display = '';
+        container.children.push(depthItem);
+
+        mockDoc.addMockElement(container);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        resetPanel();
+        global.document = originalDoc;
+
+        assert.strictEqual(depthItem.style.display, 'none', 'Non-depth-0 item should be hidden');
+    });
+
+    it('should remove fa-rotate-90 class from arrows', () => {
+        const mockDoc = new MockDocument();
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+        mockDoc.addMockElement(container);
+
+        const arrowDiv = new MockElement('div');
+        arrowDiv.classList.add('arrow');
+        const arrowIcon = new MockElement('i');
+        arrowIcon.classList.add('fa-rotate-90');
+        arrowDiv.children.push(arrowIcon);
+        mockDoc.addMockElement(arrowDiv);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        resetPanel();
+        global.document = originalDoc;
+
+        assert.strictEqual(arrowIcon.classList.contains('fa-rotate-90'), false, 'fa-rotate-90 class should be removed');
+    });
+
+    it('should handle missing panel-block-container gracefully', () => {
+        const mockDoc = new MockDocument();
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        assert.doesNotThrow(() => resetPanel());
+        global.document = originalDoc;
+    });
+});
+
+describe('initSearch', () => {
+    it('should attach input event listener to search input', () => {
+        const mockDoc = new MockDocument();
+        const searchInput = new MockElement('input');
+        searchInput.setAttribute('id', 'search-input');
+        mockDoc.setElement('search-input', searchInput);
+
+        const panelBlock = new MockElement('div');
+        panelBlock.classList.add('panel-block-container');
+        mockDoc.addMockElement(panelBlock);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initSearch();
+        global.document = originalDoc;
+
+        assert.strictEqual(searchInput.eventListeners.has('input'), true, 'Input listener should be attached');
+    });
+
+    it('should update DOM visibility based on fuzzy matching', () => {
+        const mockDoc = new MockDocument();
+        const searchInput = new MockElement('input');
+        searchInput.setAttribute('id', 'search-input');
+        searchInput.value = 'test';
+        mockDoc.setElement('search-input', searchInput);
+
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+
+        const label1 = new MockElement('label');
+        label1.textContent = 'test folder';
+        container.children.push(label1);
+
+        const label2 = new MockElement('label');
+        label2.textContent = 'other folder';
+        container.children.push(label2);
+
+        mockDoc.addMockElement(container);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initSearch();
+
+        const handlers = searchInput.eventListeners.get('input');
+        assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
+        handlers[0]();
+
+        global.document = originalDoc;
+
+        assert.strictEqual(label1.style.display, '', 'Matching label should be visible');
+        assert.strictEqual(label2.style.display, 'none', 'Non-matching label should be hidden');
+    });
+
+    it('should call resetPanel when search query is empty', () => {
+        const mockDoc = new MockDocument();
+        const searchInput = new MockElement('input');
+        searchInput.setAttribute('id', 'search-input');
+        searchInput.value = '';
+        mockDoc.setElement('search-input', searchInput);
+
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+
+        const depth0Item = new MockElement('label');
+        depth0Item.classList.add('panel-block');
+        depth0Item.setAttribute('folder-id', '');
+        depth0Item.style.display = 'none';
+        container.children.push(depth0Item);
+
+        const nonDepthItem = new MockElement('label');
+        nonDepthItem.classList.add('panel-block');
+        nonDepthItem.setAttribute('folder-id', 'folder-1');
+        nonDepthItem.style.display = '';
+        container.children.push(nonDepthItem);
+
+        mockDoc.addMockElement(container);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initSearch();
+
+        const handlers = searchInput.eventListeners.get('input');
+        assert.ok(handlers && handlers.length > 0, 'Input handlers should exist');
+        handlers[0]();
+
+        global.document = originalDoc;
+
+        assert.strictEqual(depth0Item.style.display, '', 'resetPanel should show depth-0 items');
+        assert.strictEqual(nonDepthItem.style.display, 'none', 'resetPanel should hide non-depth-0 items');
+    });
+
+    it('should attach clear search button listener if present', () => {
+        const mockDoc = new MockDocument();
+        const searchInput = new MockElement('input');
+        searchInput.setAttribute('id', 'search-input');
+        mockDoc.setElement('search-input', searchInput);
+
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+        mockDoc.addMockElement(container);
+
+        const clearButton = new MockElement('button');
+        clearButton.classList.add('clear-search');
+        mockDoc.addMockElement(clearButton);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        initSearch();
+        global.document = originalDoc;
+
+        assert.strictEqual(clearButton.eventListeners.has('click'), true, 'Clear button should have click listener');
+    });
+
+    it('should handle missing search input gracefully', () => {
+        const mockDoc = new MockDocument();
+        const container = new MockElement('div');
+        container.classList.add('panel-block-container');
+        mockDoc.addMockElement(container);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        assert.doesNotThrow(() => initSearch());
+        global.document = originalDoc;
+    });
+
+    it('should handle missing panel-block-container gracefully', () => {
+        const mockDoc = new MockDocument();
+        const searchInput = new MockElement('input');
+        searchInput.setAttribute('id', 'search-input');
+        mockDoc.setElement('search-input', searchInput);
+
+        const originalDoc = global.document;
+        global.document = mockDoc;
+        assert.doesNotThrow(() => initSearch());
+        global.document = originalDoc;
     });
 });

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "JavaScript tests for Bragibooks frontend",
   "type": "commonjs",
   "scripts": {
-    "test": "node --test importer/templates/importer.test.js",
-    "test:watch": "node --test --watch importer/templates/importer.test.js"
+    "test": "node --test 'importer/**/*.test.js'",
+    "test:watch": "node --test --watch 'importer/**/*.test.js'"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bragibooks-js-tests",
+  "version": "1.0.0",
+  "description": "JavaScript tests for Bragibooks frontend",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test importer/templates/importer.test.js",
+    "test:watch": "node --test --watch importer/templates/importer.test.js"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
Add loading overlay and spinner for initial page load and folder expansion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen loading overlay with centered loading message and indicator; search/filter UI with clear control and a “select all” option.

* **Bug Fixes / Improvements**
  * More defensive expand/collapse behavior with synchronous spinner insertion/removal and graceful handling of missing UI elements.

* **Tests**
  * Comprehensive unit tests covering overlay behavior, expand/collapse, listener wiring, fuzzy search, and panel reset.

* **Chores**
  * Added local JS test runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->