### PR TITLE
feat(importer): async directory loading with loading screen

### DIFF
--- a/importer/templates/base.html
+++ b/importer/templates/base.html
@@ -171,12 +171,19 @@
                 }
             }
 
-            // Hide pre-loader when DOM is fully loaded
+            // Export hidePreLoader globally for importer.js
+            window.hidePreLoader = hidePreLoader;
+
+            {% with request.resolver_match.url_name as url_name %}
+            {% if url_name != 'import' %}
+            // Hide pre-loader when DOM is fully loaded (skip on import page)
             if (document.readyState === 'loading') {
                 document.addEventListener('DOMContentLoaded', hidePreLoader);
             } else {
                 hidePreLoader();
             }
+            {% endif %}
+            {% endwith %}
 
             {% block script %}
             {% endblock %}

--- a/importer/templates/importer.html
+++ b/importer/templates/importer.html
@@ -96,7 +96,7 @@ to { transform: rotate(360deg); }
                     <div id="directory-error" class="panel-block" style="display: none;">
                         <span class="panel-icon"><i class="fas fa-exclamation-triangle"></i></span>
                         <span id="directory-error-message">Failed to load directories</span>
-                        <button id="directory-retry-btn" class="button is-small is-link ml-2">Retry</button>
+                        <button type="button" id="directory-retry-btn" class="button is-small is-link ml-2">Retry</button>
                     </div>
 
                     <!-- Directory tree container empty initially -->

--- a/importer/templates/importer.html
+++ b/importer/templates/importer.html
@@ -25,7 +25,7 @@ word-wrap: break-word;
 .panel-block-container {
 overflow: auto;
 max-height: 500px;
-min-heigth: 350px;
+min-height: 350px;
 display: flex;
 flex-grow: 1;
 flex-direction: column;
@@ -86,7 +86,21 @@ to { transform: rotate(360deg); }
             <form action="{% url 'import' %}" method="POST">
                 {% csrf_token %}
                 <div class="panel-block-container">
-                    {% include "directory_contents.html" %}
+                    <!-- Loading message shown initially -->
+                    <div id="directory-loading" class="panel-block">
+                        <span class="panel-icon"><i class="fas fa-spinner fa-spin"></i></span>
+                        Loading directories...
+                    </div>
+
+                    <!-- Error container hidden initially -->
+                    <div id="directory-error" class="panel-block" style="display: none;">
+                        <span class="panel-icon"><i class="fas fa-exclamation-triangle"></i></span>
+                        <span id="directory-error-message">Failed to load directories</span>
+                        <button id="directory-retry-btn" class="button is-small is-link ml-2">Retry</button>
+                    </div>
+
+                    <!-- Directory tree container empty initially -->
+                    <div id="directory-tree"></div>
                 </div>
                 <div class="panel-block">
                     <button class="button is-link is-fullwidth">Next</button>

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -151,7 +151,7 @@ function hideLoadingOverlay(doc = document) {
 }
 
 function generateId() {
-    return 'id_' + Math.random().toString(36).substr(2, 9);
+    return 'id_' + Math.random().toString(36).substring(2, 11);
 }
 
 async function fetchAndRenderDirectories() {
@@ -185,6 +185,7 @@ async function fetchAndRenderDirectories() {
         hideLoadingOverlay();
     } catch (error) {
         console.error('Failed to fetch directories:', error);
+        hideLoadingOverlay();
         if (loadingEl) loadingEl.style.display = 'none';
         if (errorEl) errorEl.style.display = '';
         if (errorMessageEl) errorMessageEl.textContent = 'Failed to load directories: ' + error.message;

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -233,7 +233,7 @@ function buildDirectoryTree(items, container, depth, parentId) {
             arrowSpan.className = 'arrow mr-2 is-medium';
             const arrowI = document.createElement('i');
             arrowI.className = 'fas fa-lg fa-angle-right';
-            arrowI.id = id;
+            arrowI.id = id + '_arrow';
             arrowSpan.appendChild(arrowI);
             label.appendChild(arrowSpan);
         } else {

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -32,7 +32,8 @@ function initArrowListeners() {
     arrows.forEach(arrow => {
         arrow.addEventListener("click", (event) => {
             event.preventDefault();
-            expandFolder(arrow.id);
+            const folderId = arrow.id.replace("_arrow", "");
+            expandFolder(folderId);
         });
     });
 }

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -223,7 +223,7 @@ function buildDirectoryTree(items, container, depth, parentId) {
             iconSpan.className = 'panel-icon';
             const iconI = document.createElement('i');
             iconI.className = 'fas fa-folder';
-            iconI.setAttribute('aria-hidden', 'false');
+            iconI.setAttribute('aria-hidden', 'true');
             iconSpan.appendChild(iconI);
             contentDiv.appendChild(iconSpan);
 
@@ -252,7 +252,7 @@ function buildDirectoryTree(items, container, depth, parentId) {
             iconSpan.className = 'panel-icon';
             const iconI = document.createElement('i');
             iconI.className = 'fas fa-file';
-            iconI.setAttribute('aria-hidden', 'false');
+            iconI.setAttribute('aria-hidden', 'true');
             iconSpan.appendChild(iconI);
             label.appendChild(iconSpan);
 
@@ -283,5 +283,5 @@ if (typeof document !== 'undefined') {
 
  // Export for testing (works in Node.js module context)
  if (typeof module !== 'undefined' && module.exports) {
-     module.exports = { hideLoadingOverlay, expandFolder, initArrowListeners, initSearch, fuzzyMatch, resetPanel };
+     module.exports = { hideLoadingOverlay, expandFolder, initArrowListeners, initSearch, fuzzyMatch, resetPanel, generateId, fetchAndRenderDirectories, buildDirectoryTree };
  }

--- a/importer/templates/importer.js
+++ b/importer/templates/importer.js
@@ -139,19 +139,146 @@ function initSearch() {
  * @param {Document} doc - The document object (defaults to global document)
  */
 function hideLoadingOverlay(doc = document) {
-    const loadingOverlay = doc.getElementById('loading-overlay');
-    if (loadingOverlay && loadingOverlay.style) {
-        loadingOverlay.style.display = 'none';
+    const preLoader = doc.getElementById('pre-loader');
+    if (preLoader) {
+        preLoader.classList.add('hidden');
+        setTimeout(function() {
+            if (preLoader && preLoader.parentNode) {
+                preLoader.parentNode.removeChild(preLoader);
+            }
+        }, 300);
     }
 }
 
- // Initialize on DOMContentLoaded for browser usage
- if (typeof document !== 'undefined') {
-     document.addEventListener('DOMContentLoaded', () => {
-         initArrowListeners();
-         initSearch();
-     });
- }
+function generateId() {
+    return 'id_' + Math.random().toString(36).substr(2, 9);
+}
+
+async function fetchAndRenderDirectories() {
+    const loadingEl = document.getElementById('directory-loading');
+    const errorEl = document.getElementById('directory-error');
+    const treeContainer = document.getElementById('directory-tree');
+    const errorMessageEl = document.getElementById('directory-error-message');
+
+    if (loadingEl) loadingEl.style.display = '';
+    if (errorEl) errorEl.style.display = 'none';
+    if (treeContainer) treeContainer.innerHTML = '';
+
+    try {
+        const response = await fetch('/api/directories/');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+
+        if (data.error) {
+            throw new Error(data.error);
+        }
+
+        if (treeContainer && data.directories) {
+            buildDirectoryTree(data.directories, treeContainer, 0, '');
+        }
+
+        if (loadingEl) loadingEl.style.display = 'none';
+        initArrowListeners();
+        initSearch();
+        hideLoadingOverlay();
+    } catch (error) {
+        console.error('Failed to fetch directories:', error);
+        if (loadingEl) loadingEl.style.display = 'none';
+        if (errorEl) errorEl.style.display = '';
+        if (errorMessageEl) errorMessageEl.textContent = 'Failed to load directories: ' + error.message;
+    }
+}
+
+function buildDirectoryTree(items, container, depth, parentId) {
+    const indent = '\u00A0'.repeat(5).repeat(depth);
+
+    items.forEach(item => {
+        const id = generateId();
+        const isDirectory = item.is_directory;
+        const display = depth === 0 ? '' : 'none';
+
+        const label = document.createElement('label');
+        label.className = isDirectory ? 'panel-block folder' : 'panel-block file';
+        label.id = id;
+        label.setAttribute('folder-id', parentId);
+        label.style.display = display;
+
+        if (isDirectory) {
+            const contentDiv = document.createElement('div');
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = 'input_dir';
+            checkbox.value = item.path;
+            contentDiv.appendChild(checkbox);
+
+            if (indent) {
+                contentDiv.appendChild(document.createTextNode(indent));
+            }
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'panel-icon';
+            const iconI = document.createElement('i');
+            iconI.className = 'fas fa-folder';
+            iconI.setAttribute('aria-hidden', 'false');
+            iconSpan.appendChild(iconI);
+            contentDiv.appendChild(iconSpan);
+
+            contentDiv.appendChild(document.createTextNode(item.name));
+            label.appendChild(contentDiv);
+
+            const arrowSpan = document.createElement('span');
+            arrowSpan.className = 'arrow mr-2 is-medium';
+            const arrowI = document.createElement('i');
+            arrowI.className = 'fas fa-lg fa-angle-right';
+            arrowI.id = id;
+            arrowSpan.appendChild(arrowI);
+            label.appendChild(arrowSpan);
+        } else {
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.name = 'input_dir';
+            checkbox.value = item.path;
+            label.appendChild(checkbox);
+
+            if (indent) {
+                label.appendChild(document.createTextNode(indent));
+            }
+
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'panel-icon';
+            const iconI = document.createElement('i');
+            iconI.className = 'fas fa-file';
+            iconI.setAttribute('aria-hidden', 'false');
+            iconSpan.appendChild(iconI);
+            label.appendChild(iconSpan);
+
+            label.appendChild(document.createTextNode(item.name));
+        }
+
+        container.appendChild(label);
+
+        if (item.children && item.children.length > 0) {
+            buildDirectoryTree(item.children, container, depth + 1, id);
+        }
+    });
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        fetchAndRenderDirectories();
+
+        const retryBtn = document.getElementById('directory-retry-btn');
+        if (retryBtn) {
+            retryBtn.addEventListener('click', (event) => {
+                event.preventDefault();
+                fetchAndRenderDirectories();
+            });
+        }
+    });
+}
 
  // Export for testing (works in Node.js module context)
  if (typeof module !== 'undefined' && module.exports) {

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -1,3 +1,165 @@
-from django.test import TestCase
+from django.test import TestCase, Client, override_settings
+from unittest.mock import patch, MagicMock
+import json
+from pathlib import Path
 
-# Create your tests here.
+
+@override_settings(
+    ALLOWED_HOSTS=["localhost", "127.0.0.1", "testserver"], APPEND_SLASH=False
+)
+class DirectoryApiTests(TestCase):
+    """Tests for the /api/directories/ API endpoint."""
+
+    def setUp(self):
+        """Set up test client."""
+        self.client = Client()
+
+    @patch("importer.views.Path")
+    def test_api_returns_200_with_valid_json_structure(self, mock_path_class):
+        """Test that API returns 200 status with valid JSON structure."""
+        # Mock /input being a directory
+        mock_input_path = MagicMock()
+        mock_input_path.is_dir.return_value = True
+        mock_input_path.exists.return_value = True
+
+        # Mock directory contents
+        mock_file = MagicMock()
+        mock_file.name = "test_file.txt"
+        mock_file.is_dir.return_value = False
+        mock_input_path.iterdir.return_value = [mock_file]
+
+        mock_path_class.return_value = mock_input_path
+        mock_path_class.home.return_value = "/home/testuser"
+
+        response = self.client.get("/api/directories/", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        # Verify JSON structure
+        self.assertIn("directories", data)
+        self.assertIn("error", data)
+        self.assertIsInstance(data["directories"], list)
+        self.assertIsNone(data["error"])
+
+    @patch("importer.views.Path")
+    def test_returns_empty_directories_when_root_not_found(self, mock_path_class):
+        """Test that API returns empty directories when root directory doesn't exist."""
+        # Mock /input not being a directory
+        mock_input_path = MagicMock()
+        mock_input_path.is_dir.return_value = False
+        mock_input_path.exists.return_value = False
+
+        mock_path_class.return_value = mock_input_path
+        mock_path_class.home.return_value = "/home/testuser"
+
+        response = self.client.get("/api/directories/", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        # Verify empty directories and error message
+        self.assertEqual(data["directories"], [])
+        self.assertIn("error", data)
+        self.assertIsNotNone(data["error"])
+        self.assertIn("Directory not found", data["error"])
+
+    @patch("importer.views.Path")
+    @patch("importer.views.directory_contents")
+    def test_returns_nested_structure_correctly(
+        self, mock_directory_contents, mock_path_class
+    ):
+        """Test that API returns nested directory structure correctly."""
+        # Mock /input being a directory
+        mock_input_path = MagicMock()
+        mock_input_path.is_dir.return_value = True
+        mock_input_path.exists.return_value = True
+
+        # Mock nested directory structure
+        mock_subdir = MagicMock()
+        mock_subdir.name = "subfolder"
+        mock_subdir.is_dir.return_value = True
+        mock_subdir.__str__.return_value = "/input/subfolder"
+
+        mock_file = MagicMock()
+        mock_file.name = "test_file.mp3"
+        mock_file.is_dir.return_value = False
+        mock_file.__str__.return_value = "/input/test_file.mp3"
+
+        mock_input_path.iterdir.return_value = [mock_subdir, mock_file]
+        mock_path_class.return_value = mock_input_path
+        mock_path_class.home.return_value = "/home/testuser"
+
+        # Mock subdirectory contents
+        mock_nested_file = MagicMock()
+        mock_nested_file.name = "nested.mp3"
+        mock_nested_file.is_dir.return_value = False
+        mock_nested_file.__str__.return_value = "/input/subfolder/nested.mp3"
+
+        mock_directory_contents.side_effect = [
+            [mock_subdir, mock_file],  # Root contents
+            [mock_nested_file],  # Subfolder contents
+        ]
+
+        response = self.client.get("/api/directories/", follow=True)
+        data = json.loads(response.content)
+
+        # Verify nested structure
+        self.assertEqual(len(data["directories"]), 2)
+
+        # Check folder entry
+        folder_entry = next(
+            (item for item in data["directories"] if item["name"] == "subfolder"), None
+        )
+        self.assertIsNotNone(folder_entry)
+        self.assertTrue(folder_entry["is_directory"])
+        self.assertEqual(folder_entry["path"], "/input/subfolder")
+        self.assertIsInstance(folder_entry["children"], list)
+        self.assertEqual(len(folder_entry["children"]), 1)
+        self.assertEqual(folder_entry["children"][0]["name"], "nested.mp3")
+
+        # Check file entry
+        file_entry = next(
+            (item for item in data["directories"] if item["name"] == "test_file.mp3"),
+            None,
+        )
+        self.assertIsNotNone(file_entry)
+        self.assertFalse(file_entry["is_directory"])
+        self.assertEqual(file_entry["children"], [])
+
+    @patch("importer.views.Path")
+    def test_error_field_is_null_on_success(self, mock_path_class):
+        """Test that error field is null when directory exists."""
+        mock_input_path = MagicMock()
+        mock_input_path.is_dir.return_value = True
+        mock_input_path.exists.return_value = True
+
+        mock_file = MagicMock()
+        mock_file.name = "test.txt"
+        mock_file.is_dir.return_value = False
+        mock_input_path.iterdir.return_value = [mock_file]
+
+        mock_path_class.return_value = mock_input_path
+        mock_path_class.home.return_value = "/home/testuser"
+
+        response = self.client.get("/api/directories/", follow=True)
+        data = json.loads(response.content)
+
+        self.assertIsNone(data["error"])
+
+    @patch("importer.views.Path")
+    def test_error_field_has_message_on_failure(self, mock_path_class):
+        """Test that error field has message when directory doesn't exist."""
+        mock_input_path = MagicMock()
+        mock_input_path.is_dir.return_value = False
+        mock_input_path.exists.return_value = False
+
+        mock_path_class.return_value = mock_input_path
+        mock_path_class.home.return_value = "/home/testuser"
+
+        response = self.client.get("/api/directories/", follow=True)
+        data = json.loads(response.content)
+
+        self.assertIsNotNone(data["error"])
+        self.assertIsInstance(data["error"], str)
+        self.assertIn("Directory not found", data["error"])

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -1,6 +1,8 @@
-from django.test import TestCase, SimpleTestCase, Client, override_settings
-from unittest.mock import patch, MagicMock
 import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.test import Client, SimpleTestCase, TestCase, override_settings
 
 from importer.views import build_directory_tree
 
@@ -60,7 +62,7 @@ class DirectoryApiTests(TestCase):
 
         response = self.client.get("/api/directories/", follow=True)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         data = json.loads(response.content)
 
         # Verify empty directories and error message
@@ -163,6 +165,8 @@ class DirectoryApiTests(TestCase):
         mock_path_class.home.return_value = "/home/testuser"
 
         response = self.client.get("/api/directories/", follow=True)
+
+        self.assertEqual(response.status_code, 404)
         data = json.loads(response.content)
 
         self.assertIsNotNone(data["error"])
@@ -198,13 +202,13 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         mock_file.name = "file.txt"
         mock_file.is_dir.return_value = False
         mock_file.__str__.return_value = "/path/file.txt"
-        mock_file.resolve.return_value = MagicMock().__str__ = "/path/file.txt"
+        mock_file.resolve.return_value = Path("/path/file.txt")
 
         mock_subdir = MagicMock()
         mock_subdir.name = "subdir"
         mock_subdir.is_dir.return_value = True
         mock_subdir.__str__.return_value = "/path/subdir"
-        mock_subdir.resolve.return_value = MagicMock().__str__ = "/path/subdir"
+        mock_subdir.resolve.return_value = Path("/path/subdir")
 
         mock_directory_contents.return_value = [mock_file, mock_subdir]
 
@@ -230,22 +234,20 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         mock_file.name = "root_file.txt"
         mock_file.is_dir.return_value = False
         mock_file.__str__.return_value = "/path/root_file.txt"
-        mock_file.resolve.return_value = MagicMock().__str__ = "/path/root_file.txt"
+        mock_file.resolve.return_value = Path("/path/root_file.txt")
 
         mock_subdir = MagicMock()
         mock_subdir.name = "subdir"
         mock_subdir.is_dir.return_value = True
         mock_subdir.__str__.return_value = "/path/subdir"
-        mock_subdir.resolve.return_value = MagicMock().__str__ = "/path/subdir"
+        mock_subdir.resolve.return_value = Path("/path/subdir")
 
         # Create mock items for second level
         mock_nested_file = MagicMock()
         mock_nested_file.name = "nested.txt"
         mock_nested_file.is_dir.return_value = False
         mock_nested_file.__str__.return_value = "/path/subdir/nested.txt"
-        mock_nested_file.resolve.return_value = MagicMock().__str__ = (
-            "/path/subdir/nested.txt"
-        )
+        mock_nested_file.resolve.return_value = Path("/path/subdir/nested.txt")
 
         # Configure side_effect to return different contents at each level
         mock_directory_contents.side_effect = [
@@ -279,16 +281,14 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         mock_dir.is_dir.return_value = True
         mock_dir.__str__.return_value = "/path/cycle_dir"
         resolved_path = "/path/cycle_dir"
-        mock_dir.resolve.return_value = MagicMock().__str__ = resolved_path
+        mock_dir.resolve.return_value = Path(resolved_path)
 
         # Create a mock file in the directory
         mock_file = MagicMock()
         mock_file.name = "file.txt"
         mock_file.is_dir.return_value = False
         mock_file.__str__.return_value = "/path/cycle_dir/file.txt"
-        mock_file.resolve.return_value = MagicMock().__str__ = (
-            "/path/cycle_dir/file.txt"
-        )
+        mock_file.resolve.return_value = Path("/path/cycle_dir/file.txt")
 
         # Return the same directory twice to simulate a cycle
         mock_directory_contents.side_effect = [
@@ -322,7 +322,7 @@ class BuildDirectoryTreeTests(SimpleTestCase):
             mock_dir.is_dir.return_value = True
             mock_dir.__str__.return_value = f"{parent_path}/{name}"
             resolved = f"{parent_path}/{name}"
-            mock_dir.resolve.return_value = MagicMock().__str__ = resolved
+            mock_dir.resolve.return_value = Path(resolved)
             return mock_dir
 
         # Create 5 levels of directories
@@ -339,7 +339,7 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         mock_file.__str__.return_value = (
             "/path/level0/level1/level2/level3/level4/deep_file.txt"
         )
-        mock_file.resolve.return_value = MagicMock().__str__ = (
+        mock_file.resolve.return_value = Path(
             "/path/level0/level1/level2/level3/level4/deep_file.txt"
         )
 

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -403,3 +403,116 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         self.assertEqual(result[0]["children"][0]["children"], [])
         # Verify directory_contents was called twice (root + subdir), not infinitely
         self.assertEqual(mock_directory_contents.call_count, 2)
+
+    @patch("importer.views.directory_contents")
+    def test_path_resolution_permission_error_returns_empty_list(
+        self, mock_directory_contents
+    ):
+        """
+        Test that path resolution raising PermissionError returns empty list.
+
+        When Path.resolve() raises PermissionError, the function should return
+        an empty list and log a debug message.
+        """
+        # Create a mock path that raises PermissionError on resolve()
+        mock_path = MagicMock()
+        mock_path.name = "unreadable_dir"
+        mock_path.__str__.return_value = "/some/unreadable"
+
+        # Make resolve() raise PermissionError
+        mock_path.resolve.side_effect = PermissionError(
+            "Permission denied: /some/unreadable"
+        )
+
+        # Configure directory_contents to return valid items
+        # but they won't be reached because resolve() fails first
+        mock_directory_contents.return_value = []
+
+        result = build_directory_tree(mock_path)
+
+        # Should return empty list
+        self.assertEqual(result, [])
+        # directory_contents should not be called because resolve failed
+        mock_directory_contents.assert_not_called()
+
+    @patch("importer.views.directory_contents")
+    def test_path_resolution_os_error_returns_empty_list(self, mock_directory_contents):
+        """
+        Test that path resolution raising OSError returns empty list.
+
+        When Path.resolve() raises OSError, the function should return
+        an empty list and log a debug message.
+        """
+        # Create a mock path that raises OSError on resolve()
+        mock_path = MagicMock()
+        mock_path.name = "bad_link"
+        mock_path.__str__.return_value = "/some/bad_link"
+
+        # Make resolve() raise OSError
+        mock_path.resolve.side_effect = OSError("Input/output error: /some/bad_link")
+
+        # Configure directory_contents
+        mock_directory_contents.return_value = []
+
+        result = build_directory_tree(mock_path)
+
+        # Should return empty list
+        self.assertEqual(result, [])
+        # directory_contents should not be called because resolve failed
+        mock_directory_contents.assert_not_called()
+
+    @patch("importer.views.directory_contents")
+    def test_directory_access_permission_error_returns_empty_entries(
+        self, mock_directory_contents
+    ):
+        """
+        Test that directory access raising PermissionError returns empty entries list.
+
+        When directory_contents() raises PermissionError, the function should return
+        empty entries list and log a warning.
+        """
+        # Create a mock path
+        mock_path = MagicMock()
+        mock_path.name = "restricted_dir"
+        mock_path.is_dir.return_value = True
+        mock_path.__str__.return_value = "/restricted/dir"
+        mock_path.resolve.return_value = Path("/restricted/dir")
+
+        # Make directory_contents raise PermissionError
+        mock_directory_contents.side_effect = PermissionError(
+            "Permission denied: /restricted/dir"
+        )
+
+        result = build_directory_tree(mock_path)
+
+        # Should return empty list (no entries added)
+        self.assertEqual(result, [])
+        # directory_contents should be called once
+        mock_directory_contents.assert_called_once()
+
+    @patch("importer.views.directory_contents")
+    def test_directory_access_os_error_returns_empty_entries(
+        self, mock_directory_contents
+    ):
+        """
+        Test that directory access raising OSError returns empty entries list.
+
+        When directory_contents() raises OSError, the function should return
+        empty entries list and log a warning.
+        """
+        # Create a mock path
+        mock_path = MagicMock()
+        mock_path.name = "unreadable"
+        mock_path.is_dir.return_value = True
+        mock_path.__str__.return_value = "/unreadable"
+        mock_path.resolve.return_value = Path("/unreadable")
+
+        # Make directory_contents raise OSError
+        mock_directory_contents.side_effect = OSError("I/O error: /unreadable")
+
+        result = build_directory_tree(mock_path)
+
+        # Should return empty list (no entries added)
+        self.assertEqual(result, [])
+        # directory_contents should be called once
+        mock_directory_contents.assert_called_once()

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -64,6 +64,7 @@ class DirectoryApiTests(TestCase):
     @patch("importer.views.Path")
     def test_returns_empty_directories_when_root_not_found(self, mock_path_class):
         """Test that API returns empty directories when root directory doesn't exist."""
+        self.client.force_login(self.user)
         # Mock /input not being a directory
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = False
@@ -291,7 +292,7 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         Test that symlink cycles are detected using the visited set.
 
         When build_directory_tree processes a directory whose contents include
-        a symlink back to a directory already in the visited set, the visited‑set
+        a symlink back to a directory already in the visited set, the visited-set
         logic skips reentering that directory so the final children list only
         contains the file.
         """
@@ -312,10 +313,10 @@ class BuildDirectoryTreeTests(SimpleTestCase):
 
         # Configure directory_contents to simulate a symlink cycle:
         # 1. Root path returns cycle_dir
-        # 2. cycle_dir's contents include itself (self‑reference) + the file
+        # 2. cycle_dir's contents include itself (self-reference) + the file
         mock_directory_contents.side_effect = [
             [mock_dir],  # Root path ("cycle_dir")
-            [mock_dir, mock_file],  # cycle_dir contents: self‑reference + file
+            [mock_dir, mock_file],  # cycle_dir contents: self-reference + file
         ]
 
         result = build_directory_tree("/some/path", max_depth=50)

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -44,7 +44,6 @@ class DirectoryApiTests(TestCase):
         mock_file = MagicMock()
         mock_file.name = "test_file.txt"
         mock_file.is_dir.return_value = False
-        mock_input_path.iterdir.return_value = [mock_file]
         mock_directory_contents.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
@@ -162,7 +161,6 @@ class DirectoryApiTests(TestCase):
         mock_file = MagicMock()
         mock_file.name = "test.txt"
         mock_file.is_dir.return_value = False
-        mock_input_path.iterdir.return_value = [mock_file]
         mock_directory_contents.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
@@ -176,6 +174,7 @@ class DirectoryApiTests(TestCase):
     @patch("importer.views.Path")
     def test_error_field_has_message_on_failure(self, mock_path_class):
         """Test that error field has message when directory doesn't exist."""
+        self.client.force_login(self.user)
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = False
         mock_input_path.exists.return_value = False
@@ -400,8 +399,6 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         across multiple recursive calls, the self-reference detection prevents
         infinite recursion by skipping self-referential items.
         """
-        from pathlib import Path
-
         # Create a mock directory that will be revisited
         mock_dir = MagicMock()
         mock_dir.name = "same_dir"

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -17,6 +17,13 @@ class DirectoryApiTests(TestCase):
         """Set up test client."""
         self.client = Client()
 
+    def test_unauthenticated_request_redirects_to_login(self):
+        """Test that unauthenticated requests are redirected to login page."""
+        response = self.client.get("/api/directories/")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.url)
+
     @patch("importer.views.Path")
     @patch("importer.views.directory_contents")
     def test_api_returns_200_with_valid_json_structure(
@@ -135,7 +142,10 @@ class DirectoryApiTests(TestCase):
         self.assertEqual(file_entry["children"], [])
 
     @patch("importer.views.Path")
-    def test_error_field_is_null_on_success(self, mock_path_class):
+    @patch("importer.views.directory_contents")
+    def test_error_field_is_null_on_success(
+        self, mock_directory_contents, mock_path_class
+    ):
         """Test that error field is null when directory exists."""
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = True
@@ -145,6 +155,7 @@ class DirectoryApiTests(TestCase):
         mock_file.name = "test.txt"
         mock_file.is_dir.return_value = False
         mock_input_path.iterdir.return_value = [mock_file]
+        mock_directory_contents.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
         mock_path_class.home.return_value = mock_input_path

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -17,9 +17,7 @@ class DirectoryApiTests(TestCase):
     def setUp(self):
         """Set up test client and user."""
         self.client = Client()
-        self.user = User.objects.create_user(
-            username="testuser", password="testpass123"
-        )
+        self.user = User.objects.create_user(username="testuser")
 
     def test_unauthenticated_request_redirects_to_login(self):
         """Test that unauthenticated requests are redirected to login page."""

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -36,7 +36,7 @@ class DirectoryApiTests(TestCase):
         mock_directory_contents.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
-        mock_path_class.home.return_value = "/home/testuser"
+        mock_path_class.home.return_value = mock_input_path
 
         response = self.client.get("/api/directories/", follow=True)
 
@@ -58,7 +58,7 @@ class DirectoryApiTests(TestCase):
         mock_input_path.exists.return_value = False
 
         mock_path_class.return_value = mock_input_path
-        mock_path_class.home.return_value = "/home/testuser"
+        mock_path_class.home.return_value = mock_input_path
 
         response = self.client.get("/api/directories/", follow=True)
 
@@ -95,7 +95,7 @@ class DirectoryApiTests(TestCase):
 
         mock_input_path.iterdir.return_value = [mock_subdir, mock_file]
         mock_path_class.return_value = mock_input_path
-        mock_path_class.home.return_value = "/home/testuser"
+        mock_path_class.home.return_value = mock_input_path
 
         # Mock subdirectory contents
         mock_nested_file = MagicMock()
@@ -147,7 +147,7 @@ class DirectoryApiTests(TestCase):
         mock_input_path.iterdir.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
-        mock_path_class.home.return_value = "/home/testuser"
+        mock_path_class.home.return_value = mock_input_path
 
         response = self.client.get("/api/directories/", follow=True)
         data = json.loads(response.content)
@@ -162,7 +162,7 @@ class DirectoryApiTests(TestCase):
         mock_input_path.exists.return_value = False
 
         mock_path_class.return_value = mock_input_path
-        mock_path_class.home.return_value = "/home/testuser"
+        mock_path_class.home.return_value = mock_input_path
 
         response = self.client.get("/api/directories/", follow=True)
 

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from django.contrib.auth.models import User
 from django.test import Client, SimpleTestCase, TestCase, override_settings
 
 from importer.views import build_directory_tree
@@ -14,8 +15,11 @@ class DirectoryApiTests(TestCase):
     """Tests for the /api/directories/ API endpoint."""
 
     def setUp(self):
-        """Set up test client."""
+        """Set up test client and user."""
         self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpass123"
+        )
 
     def test_unauthenticated_request_redirects_to_login(self):
         """Test that unauthenticated requests are redirected to login page."""
@@ -30,6 +34,7 @@ class DirectoryApiTests(TestCase):
         self, mock_directory_contents, mock_path_class
     ):
         """Test that API returns 200 status with valid JSON structure."""
+        self.client.force_login(self.user)
         # Mock /input being a directory
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = True
@@ -84,6 +89,7 @@ class DirectoryApiTests(TestCase):
         self, mock_directory_contents, mock_path_class
     ):
         """Test that API returns nested directory structure correctly."""
+        self.client.force_login(self.user)
         # Mock /input being a directory
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = True
@@ -147,6 +153,7 @@ class DirectoryApiTests(TestCase):
         self, mock_directory_contents, mock_path_class
     ):
         """Test that error field is null when directory exists."""
+        self.client.force_login(self.user)
         mock_input_path = MagicMock()
         mock_input_path.is_dir.return_value = True
         mock_input_path.exists.return_value = True
@@ -283,8 +290,10 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         """
         Test that symlink cycles are detected using the visited set.
 
-        When a symlink points to a directory already in the visited set,
-        the function should return an empty children list to prevent infinite loops.
+        When build_directory_tree processes a directory whose contents include
+        a symlink back to a directory already in the visited set, the visited‑set
+        logic skips reentering that directory so the final children list only
+        contains the file.
         """
         # Create a mock directory that will be revisited (simulating a symlink cycle)
         mock_dir = MagicMock()
@@ -301,19 +310,19 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         mock_file.__str__.return_value = "/path/cycle_dir/file.txt"
         mock_file.resolve.return_value = Path("/path/cycle_dir/file.txt")
 
-        # Return the same directory twice to simulate a cycle
+        # Configure directory_contents to simulate a symlink cycle:
+        # 1. Root path returns cycle_dir
+        # 2. cycle_dir's contents include itself (self‑reference) + the file
         mock_directory_contents.side_effect = [
-            [mock_dir],  # First visit to cycle_dir
-            [mock_file],  # Contents of cycle_dir
-            [mock_dir],  # Second visit (cycle detected here)
+            [mock_dir],  # Root path ("cycle_dir")
+            [mock_dir, mock_file],  # cycle_dir contents: self‑reference + file
         ]
 
         result = build_directory_tree("/some/path", max_depth=50)
 
-        # First visit should work normally
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "cycle_dir")
-        # Children should be present from first visit
+        # Children list contains only the file (directory skipped due to visited set)
         self.assertEqual(len(result[0]["children"]), 1)
         self.assertEqual(result[0]["children"][0]["name"], "file.txt")
 
@@ -386,8 +395,9 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         """
         Test that the visited set prevents infinite recursion on circular references.
 
-        This test verifies that the same resolved path is tracked across
-        recursive calls to prevent infinite loops.
+        This test verifies that when directory_contents returns the same directory
+        across multiple recursive calls, the self-reference detection prevents
+        infinite recursion by skipping self-referential items.
         """
         from pathlib import Path
 
@@ -408,11 +418,10 @@ class BuildDirectoryTreeTests(SimpleTestCase):
         # Should return one entry (directory is added on first visit)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "same_dir")
-        # Children contain one entry from first visit (second visit returns empty due to cycle)
-        self.assertEqual(len(result[0]["children"]), 1)
-        self.assertEqual(result[0]["children"][0]["name"], "same_dir")
-        self.assertEqual(result[0]["children"][0]["children"], [])
-        # Verify directory_contents was called twice (root + subdir), not infinitely
+        # The self-reference in the directory's contents is skipped (detected by
+        # comparing resolved path with current directory's path), resulting in empty children
+        self.assertEqual(len(result[0]["children"]), 0)
+        # Verify directory_contents was called twice (root + one recursive call), not infinitely
         self.assertEqual(mock_directory_contents.call_count, 2)
 
     @patch("importer.views.directory_contents")

--- a/importer/tests.py
+++ b/importer/tests.py
@@ -1,7 +1,8 @@
-from django.test import TestCase, Client, override_settings
+from django.test import TestCase, SimpleTestCase, Client, override_settings
 from unittest.mock import patch, MagicMock
 import json
-from pathlib import Path
+
+from importer.views import build_directory_tree
 
 
 @override_settings(
@@ -15,7 +16,10 @@ class DirectoryApiTests(TestCase):
         self.client = Client()
 
     @patch("importer.views.Path")
-    def test_api_returns_200_with_valid_json_structure(self, mock_path_class):
+    @patch("importer.views.directory_contents")
+    def test_api_returns_200_with_valid_json_structure(
+        self, mock_directory_contents, mock_path_class
+    ):
         """Test that API returns 200 status with valid JSON structure."""
         # Mock /input being a directory
         mock_input_path = MagicMock()
@@ -27,6 +31,7 @@ class DirectoryApiTests(TestCase):
         mock_file.name = "test_file.txt"
         mock_file.is_dir.return_value = False
         mock_input_path.iterdir.return_value = [mock_file]
+        mock_directory_contents.return_value = [mock_file]
 
         mock_path_class.return_value = mock_input_path
         mock_path_class.home.return_value = "/home/testuser"
@@ -163,3 +168,238 @@ class DirectoryApiTests(TestCase):
         self.assertIsNotNone(data["error"])
         self.assertIsInstance(data["error"], str)
         self.assertIn("Directory not found", data["error"])
+
+
+class BuildDirectoryTreeTests(SimpleTestCase):
+    """Tests for the build_directory_tree function safety features."""
+
+    @patch("importer.views.directory_contents")
+    def test_max_depth_zero_returns_empty_list(self, mock_directory_contents):
+        """
+        Test that max_depth=0 returns an empty list immediately.
+
+        When max_depth is 0, the function should not recurse at all
+        and should return an empty list.
+        """
+        result = build_directory_tree("/some/path", max_depth=0)
+        self.assertEqual(result, [])
+        mock_directory_contents.assert_not_called()
+
+    @patch("importer.views.directory_contents")
+    def test_max_depth_one_returns_root_level_only(self, mock_directory_contents):
+        """
+        Test that max_depth=1 returns only root level items without children.
+
+        When max_depth is 1, the function should return items at the root
+        level but their children should be empty lists (no recursion).
+        """
+        # Create mock items
+        mock_file = MagicMock()
+        mock_file.name = "file.txt"
+        mock_file.is_dir.return_value = False
+        mock_file.__str__.return_value = "/path/file.txt"
+        mock_file.resolve.return_value = MagicMock().__str__ = "/path/file.txt"
+
+        mock_subdir = MagicMock()
+        mock_subdir.name = "subdir"
+        mock_subdir.is_dir.return_value = True
+        mock_subdir.__str__.return_value = "/path/subdir"
+        mock_subdir.resolve.return_value = MagicMock().__str__ = "/path/subdir"
+
+        mock_directory_contents.return_value = [mock_file, mock_subdir]
+
+        result = build_directory_tree("/some/path", max_depth=1)
+
+        # Should return both items with empty children
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["name"], "file.txt")
+        self.assertEqual(result[0]["children"], [])
+        self.assertEqual(result[1]["name"], "subdir")
+        self.assertEqual(result[1]["children"], [])
+
+    @patch("importer.views.directory_contents")
+    def test_max_depth_two_returns_two_levels(self, mock_directory_contents):
+        """
+        Test that max_depth=2 returns items two levels deep.
+
+        When max_depth is 2, the function should return root level items
+        and one level of children for directories.
+        """
+        # Create mock items for root level
+        mock_file = MagicMock()
+        mock_file.name = "root_file.txt"
+        mock_file.is_dir.return_value = False
+        mock_file.__str__.return_value = "/path/root_file.txt"
+        mock_file.resolve.return_value = MagicMock().__str__ = "/path/root_file.txt"
+
+        mock_subdir = MagicMock()
+        mock_subdir.name = "subdir"
+        mock_subdir.is_dir.return_value = True
+        mock_subdir.__str__.return_value = "/path/subdir"
+        mock_subdir.resolve.return_value = MagicMock().__str__ = "/path/subdir"
+
+        # Create mock items for second level
+        mock_nested_file = MagicMock()
+        mock_nested_file.name = "nested.txt"
+        mock_nested_file.is_dir.return_value = False
+        mock_nested_file.__str__.return_value = "/path/subdir/nested.txt"
+        mock_nested_file.resolve.return_value = MagicMock().__str__ = (
+            "/path/subdir/nested.txt"
+        )
+
+        # Configure side_effect to return different contents at each level
+        mock_directory_contents.side_effect = [
+            [mock_file, mock_subdir],  # Root level
+            [mock_nested_file],  # Second level
+        ]
+
+        result = build_directory_tree("/some/path", max_depth=2)
+
+        # Should return root items with subdir having one child
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["name"], "root_file.txt")
+        self.assertEqual(result[0]["children"], [])
+
+        self.assertEqual(result[1]["name"], "subdir")
+        self.assertEqual(len(result[1]["children"]), 1)
+        self.assertEqual(result[1]["children"][0]["name"], "nested.txt")
+        self.assertEqual(result[1]["children"][0]["children"], [])
+
+    @patch("importer.views.directory_contents")
+    def test_symlink_cycle_detection(self, mock_directory_contents):
+        """
+        Test that symlink cycles are detected using the visited set.
+
+        When a symlink points to a directory already in the visited set,
+        the function should return an empty children list to prevent infinite loops.
+        """
+        # Create a mock directory that will be revisited (simulating a symlink cycle)
+        mock_dir = MagicMock()
+        mock_dir.name = "cycle_dir"
+        mock_dir.is_dir.return_value = True
+        mock_dir.__str__.return_value = "/path/cycle_dir"
+        resolved_path = "/path/cycle_dir"
+        mock_dir.resolve.return_value = MagicMock().__str__ = resolved_path
+
+        # Create a mock file in the directory
+        mock_file = MagicMock()
+        mock_file.name = "file.txt"
+        mock_file.is_dir.return_value = False
+        mock_file.__str__.return_value = "/path/cycle_dir/file.txt"
+        mock_file.resolve.return_value = MagicMock().__str__ = (
+            "/path/cycle_dir/file.txt"
+        )
+
+        # Return the same directory twice to simulate a cycle
+        mock_directory_contents.side_effect = [
+            [mock_dir],  # First visit to cycle_dir
+            [mock_file],  # Contents of cycle_dir
+            [mock_dir],  # Second visit (cycle detected here)
+        ]
+
+        result = build_directory_tree("/some/path", max_depth=50)
+
+        # First visit should work normally
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "cycle_dir")
+        # Children should be present from first visit
+        self.assertEqual(len(result[0]["children"]), 1)
+        self.assertEqual(result[0]["children"][0]["name"], "file.txt")
+
+    @patch("importer.views.directory_contents")
+    def test_deeply_nested_directory_with_depth_limit(self, mock_directory_contents):
+        """
+        Test proper handling of deeply nested directories with depth limit.
+
+        Verifies that the function correctly limits recursion depth
+        even when there are many nested levels.
+        """
+
+        # Create a chain of nested directories
+        def create_mock_dir(name, parent_path):
+            mock_dir = MagicMock()
+            mock_dir.name = name
+            mock_dir.is_dir.return_value = True
+            mock_dir.__str__.return_value = f"{parent_path}/{name}"
+            resolved = f"{parent_path}/{name}"
+            mock_dir.resolve.return_value = MagicMock().__str__ = resolved
+            return mock_dir
+
+        # Create 5 levels of directories
+        level0 = create_mock_dir("level0", "/path")
+        level1 = create_mock_dir("level1", "/path/level0")
+        level2 = create_mock_dir("level2", "/path/level0/level1")
+        level3 = create_mock_dir("level3", "/path/level0/level1/level2")
+        level4 = create_mock_dir("level4", "/path/level0/level1/level2/level3")
+
+        # Mock file at deepest level
+        mock_file = MagicMock()
+        mock_file.name = "deep_file.txt"
+        mock_file.is_dir.return_value = False
+        mock_file.__str__.return_value = (
+            "/path/level0/level1/level2/level3/level4/deep_file.txt"
+        )
+        mock_file.resolve.return_value = MagicMock().__str__ = (
+            "/path/level0/level1/level2/level3/level4/deep_file.txt"
+        )
+
+        # Configure directory contents for each level
+        mock_directory_contents.side_effect = [
+            [level0],  # Level 0
+            [level1],  # Level 1
+            [level2],  # Level 2
+            [level3],  # Level 3
+            [level4],  # Level 4
+            [mock_file],  # Level 5 (should not be reached with max_depth=5)
+        ]
+
+        result = build_directory_tree("/path", max_depth=5)
+
+        # With max_depth=5, we should get 5 levels of directories
+        # Level 0 -> Level 1 -> Level 2 -> Level 3 -> Level 4 (no children)
+        self.assertEqual(len(result), 1)  # Only level0 at root
+
+        current = result[0]
+        expected_depth = 5
+        for i in range(expected_depth):
+            self.assertEqual(current["name"], f"level{i}")
+            if i < expected_depth - 1:
+                self.assertEqual(len(current["children"]), 1)
+                current = current["children"][0]
+            else:
+                # Last level should have no children (depth limit reached)
+                self.assertEqual(current["children"], [])
+
+    @patch("importer.views.directory_contents")
+    def test_visited_set_prevents_infinite_recursion(self, mock_directory_contents):
+        """
+        Test that the visited set prevents infinite recursion on circular references.
+
+        This test verifies that the same resolved path is tracked across
+        recursive calls to prevent infinite loops.
+        """
+        from pathlib import Path
+
+        # Create a mock directory that will be revisited
+        mock_dir = MagicMock()
+        mock_dir.name = "same_dir"
+        mock_dir.is_dir.return_value = True
+        mock_dir.__str__.return_value = "/path/same_dir"
+        # Use a real Path object for resolve() so comparisons work correctly
+        mock_dir.resolve.return_value = Path("/path/same_dir")
+
+        # Return the same directory multiple times
+        mock_directory_contents.return_value = [mock_dir]
+
+        # Call with a very high max_depth - should not infinite loop
+        result = build_directory_tree("/some/path", max_depth=100)
+
+        # Should return one entry (directory is added on first visit)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "same_dir")
+        # Children contain one entry from first visit (second visit returns empty due to cycle)
+        self.assertEqual(len(result[0]["children"]), 1)
+        self.assertEqual(result[0]["children"][0]["name"], "same_dir")
+        self.assertEqual(result[0]["children"][0]["children"], [])
+        # Verify directory_contents was called twice (root + subdir), not infinitely
+        self.assertEqual(mock_directory_contents.call_count, 2)

--- a/importer/urls.py
+++ b/importer/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path, re_path
 from . import views
+
 urlpatterns = [
-    path('', views.ImportView.as_view(), name='import'),
-    path('match', views.MatchView.as_view(), name='match'),
-    re_path(r'^asin-search/$', views.AsinSearch.as_view(), name='asin-search'),
-    path('books', views.BookListView.as_view(), name='books'),
-    path('setting', views.SettingView.as_view(), name='setting'),
+    path("", views.ImportView.as_view(), name="import"),
+    path("match", views.MatchView.as_view(), name="match"),
+    re_path(r"^asin-search/$", views.AsinSearch.as_view(), name="asin-search"),
+    path("books", views.BookListView.as_view(), name="books"),
+    path("setting", views.SettingView.as_view(), name="setting"),
+    path("api/directories/", views.DirectoryListView.as_view(), name="api-directories"),
 ]

--- a/importer/views.py
+++ b/importer/views.py
@@ -384,22 +384,32 @@ def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
     try:
         # Resolve path to detect real identity for cycle detection
         resolved_path = str(path.resolve()) if hasattr(path, "resolve") else str(path)
-
-        # Check for cycles from symlinks
-        if resolved_path in visited:
-            logger.debug("Cycle detected, skipping: %s", resolved_path)
-            return []
-
-        visited.add(resolved_path)
     except (PermissionError, OSError) as e:
         logger.debug("Could not resolve path %s: %s", path, e)
         return []
+
+    # Check for cycles from symlinks
+    if resolved_path in visited:
+        logger.debug("Cycle detected, skipping: %s", resolved_path)
+        return []
+
+    visited.add(resolved_path)
 
     entries = []
     try:
         contents = directory_contents(path)
         for item in contents:
             is_dir = item.is_dir()
+            if is_dir:
+                try:
+                    item_resolved = str(item.resolve())
+                    if item_resolved == resolved_path:
+                        logger.debug(
+                            "Self-reference detected, skipping: %s", item_resolved
+                        )
+                        continue
+                except (PermissionError, OSError):
+                    pass
             entry = {
                 "name": item.name,
                 "path": str(item),

--- a/importer/views.py
+++ b/importer/views.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import requests
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import (
     HttpRequest,
     HttpResponseBadRequest,
@@ -14,6 +15,7 @@ from django.http import (
 )
 from django.shortcuts import redirect, render
 from django.views.generic import TemplateView, View
+from django.db import DatabaseError
 
 # core merge logic:
 from m4b_merge import helpers
@@ -53,7 +55,7 @@ def get_input_root_dir():
         setting = Setting.objects.first()
         if setting and setting.input_directory:
             return setting.input_directory
-    except Exception as e:
+    except DatabaseError as e:
         logger.debug("Could not read input_directory from Setting: %s", e)
 
     # Fallback to default logic
@@ -417,7 +419,7 @@ def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
     return entries
 
 
-class DirectoryListView(View):
+class DirectoryListView(LoginRequiredMixin, View):
     """
     API endpoint that returns directory contents as JSON.
     """

--- a/importer/views.py
+++ b/importer/views.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import requests
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpRequest, HttpResponseBadRequest, JsonResponse
+from django.http import (
+    HttpRequest,
+    HttpResponseBadRequest,
+    JsonResponse,
+)
 from django.shortcuts import redirect, render
 from django.views.generic import TemplateView, View
 
@@ -23,12 +27,12 @@ from utils.search_tools import ScoreTool, SearchTool
 # Forms import
 from .forms import SettingForm
 
-# Template tags import for directory_contents
-from .templatetags.directory_explorer_tags import directory_contents
-
 # Models import
 from .models import Book, Setting, StatusChoices
 from .tasks import m4b_merge_task
+
+# Template tags import for directory_contents
+from .templatetags.directory_explorer_tags import directory_contents
 
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
@@ -351,7 +355,9 @@ def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
         List of directory entry dictionaries.
     """
     if current_depth >= max_depth:
-        logger.debug(f"Max depth ({max_depth}) reached, stopping recursion at: {path}")
+        logger.debug(
+            "Max depth (%s) reached, stopping recursion at: %s", max_depth, path
+        )
         return []
 
     if visited is None:
@@ -363,12 +369,12 @@ def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
 
         # Check for cycles from symlinks
         if resolved_path in visited:
-            logger.debug(f"Cycle detected, skipping: {resolved_path}")
+            logger.debug("Cycle detected, skipping: %s", resolved_path)
             return []
 
         visited.add(resolved_path)
     except (PermissionError, OSError) as e:
-        logger.debug(f"Could not resolve path {path}: {e}")
+        logger.debug("Could not resolve path %s: %s", path, e)
         return []
 
     entries = []
@@ -388,9 +394,9 @@ def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
             }
             entries.append(entry)
     except PermissionError as e:
-        logger.warning(f"Permission denied accessing {path}: {e}")
+        logger.warning("Permission denied accessing %s: %s", path, e)
     except OSError as e:
-        logger.warning(f"OS error accessing {path}: {e}")
+        logger.warning("OS error accessing %s: %s", path, e)
 
     return entries
 
@@ -406,7 +412,8 @@ class DirectoryListView(View):
         # Check if root directory exists
         if not Path(rootdir).exists():
             return JsonResponse(
-                {"directories": [], "error": f"Directory not found: {rootdir}"}
+                {"directories": [], "error": f"Directory not found: {rootdir}"},
+                status=404,
             )
 
         # Build directory tree

--- a/importer/views.py
+++ b/importer/views.py
@@ -23,6 +23,9 @@ from utils.search_tools import ScoreTool, SearchTool
 # Forms import
 from .forms import SettingForm
 
+# Template tags import for directory_contents
+from .templatetags.directory_explorer_tags import directory_contents
+
 # Models import
 from .models import Book, Setting, StatusChoices
 from .tasks import m4b_merge_task
@@ -320,5 +323,50 @@ class SettingView(TemplateView):
 
             return redirect("import")
 
-        messages.error(request, "Form is invalid")
+            messages.error(request, "Form is invalid")
         return redirect("setting")
+
+
+def build_directory_tree(path):
+    """
+    Recursively build directory tree structure for JSON response.
+    """
+    entries = []
+    try:
+        contents = directory_contents(path)
+        for item in contents:
+            is_dir = item.is_dir()
+            entry = {
+                "name": item.name,
+                "path": str(item),
+                "is_directory": is_dir,
+                "children": build_directory_tree(item) if is_dir else [],
+            }
+            entries.append(entry)
+    except (PermissionError, OSError):
+        pass
+    return entries
+
+
+class DirectoryListView(View):
+    """
+    API endpoint that returns directory contents as JSON.
+    """
+
+    def get(self, request):
+        # Determine root directory (same logic as ImportView)
+        if Path("/input").is_dir():
+            rootdir = "/input"
+        else:
+            rootdir = f"{str(Path.home())}/input"
+
+        # Check if root directory exists
+        if not Path(rootdir).exists():
+            return JsonResponse(
+                {"directories": [], "error": f"Directory not found: {rootdir}"}
+            )
+
+        # Build directory tree
+        directories = build_directory_tree(rootdir)
+
+        return JsonResponse({"directories": directories, "error": None})

--- a/importer/views.py
+++ b/importer/views.py
@@ -58,11 +58,18 @@ class ImportView(TemplateView):
     template_name = "importer.html"
 
     def get_context_data(self, **kwargs):
-        context = {
-            "contents": sorted(
+        try:
+            contents = sorted(
                 Path(rootdir).iterdir(), key=os.path.getmtime, reverse=True
             )
-        }
+        except (OSError, PermissionError) as e:
+            logger.warning(
+                "Cannot access input directory %s: %s. Falling back to empty list.",
+                rootdir,
+                e,
+            )
+            contents = []
+        context = {"contents": contents}
         return context
 
     def post(self, request):

--- a/importer/views.py
+++ b/importer/views.py
@@ -47,7 +47,7 @@ def get_input_root_dir():
     """
     if Path("/input").is_dir():
         return "/input"
-    return f"{str(Path.home())}/input"
+    return str(Path.home() / "input")
 
 
 # Module-level rootdir for ImportView compatibility

--- a/importer/views.py
+++ b/importer/views.py
@@ -33,11 +33,21 @@ from .tasks import m4b_merge_task
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
-# If using docker, default to /input folder, else $USER/input
-if Path("/input").is_dir():
-    rootdir = "/input"
-else:
-    rootdir = f"{str(Path.home())}/input"
+
+def get_input_root_dir():
+    """
+    Determine the input root directory.
+
+    Returns:
+        Path to the input directory (/input if running in Docker, otherwise ~/input).
+    """
+    if Path("/input").is_dir():
+        return "/input"
+    return f"{str(Path.home())}/input"
+
+
+# Module-level rootdir for ImportView compatibility
+rootdir = get_input_root_dir()
 
 
 class ImportView(TemplateView):
@@ -327,10 +337,40 @@ class SettingView(TemplateView):
         return redirect("setting")
 
 
-def build_directory_tree(path):
+def build_directory_tree(path, max_depth=50, current_depth=0, visited=None):
     """
     Recursively build directory tree structure for JSON response.
+
+    Args:
+        path: Current directory path to explore.
+        max_depth: Maximum recursion depth to prevent infinite loops (default: 50).
+        current_depth: Current recursion depth (default: 0).
+        visited: Set of resolved paths to detect symlink cycles (default: None).
+
+    Returns:
+        List of directory entry dictionaries.
     """
+    if current_depth >= max_depth:
+        logger.debug(f"Max depth ({max_depth}) reached, stopping recursion at: {path}")
+        return []
+
+    if visited is None:
+        visited = set()
+
+    try:
+        # Resolve path to detect real identity for cycle detection
+        resolved_path = str(path.resolve()) if hasattr(path, "resolve") else str(path)
+
+        # Check for cycles from symlinks
+        if resolved_path in visited:
+            logger.debug(f"Cycle detected, skipping: {resolved_path}")
+            return []
+
+        visited.add(resolved_path)
+    except (PermissionError, OSError) as e:
+        logger.debug(f"Could not resolve path {path}: {e}")
+        return []
+
     entries = []
     try:
         contents = directory_contents(path)
@@ -340,11 +380,18 @@ def build_directory_tree(path):
                 "name": item.name,
                 "path": str(item),
                 "is_directory": is_dir,
-                "children": build_directory_tree(item) if is_dir else [],
+                "children": build_directory_tree(
+                    item, max_depth, current_depth + 1, visited
+                )
+                if is_dir
+                else [],
             }
             entries.append(entry)
-    except (PermissionError, OSError):
-        pass
+    except PermissionError as e:
+        logger.warning(f"Permission denied accessing {path}: {e}")
+    except OSError as e:
+        logger.warning(f"OS error accessing {path}: {e}")
+
     return entries
 
 
@@ -354,11 +401,7 @@ class DirectoryListView(View):
     """
 
     def get(self, request):
-        # Determine root directory (same logic as ImportView)
-        if Path("/input").is_dir():
-            rootdir = "/input"
-        else:
-            rootdir = f"{str(Path.home())}/input"
+        rootdir = get_input_root_dir()
 
         # Check if root directory exists
         if not Path(rootdir).exists():

--- a/importer/views.py
+++ b/importer/views.py
@@ -322,7 +322,7 @@ class SettingView(TemplateView):
                 es.save()
 
             return redirect("import")
-
+        else:
             messages.error(request, "Form is invalid")
         return redirect("setting")
 

--- a/importer/views.py
+++ b/importer/views.py
@@ -42,22 +42,31 @@ def get_input_root_dir():
     """
     Determine the input root directory.
 
+    Reads from Setting.input_directory if available, otherwise falls back to
+    /input (if running in Docker) or ~/input.
+
     Returns:
-        Path to the input directory (/input if running in Docker, otherwise ~/input).
+        Path to the input directory as a string.
     """
+    # Try to get the configured directory from settings
+    try:
+        setting = Setting.objects.first()
+        if setting and setting.input_directory:
+            return setting.input_directory
+    except Exception as e:
+        logger.debug("Could not read input_directory from Setting: %s", e)
+
+    # Fallback to default logic
     if Path("/input").is_dir():
         return "/input"
     return str(Path.home() / "input")
-
-
-# Module-level rootdir for ImportView compatibility
-rootdir = get_input_root_dir()
 
 
 class ImportView(TemplateView):
     template_name = "importer.html"
 
     def get_context_data(self, **kwargs):
+        rootdir = get_input_root_dir()
         try:
             contents = sorted(
                 Path(rootdir).iterdir(), key=os.path.getmtime, reverse=True


### PR DESCRIPTION
## Summary

Refactors the import page to load directory contents asynchronously via AJAX, showing a loading screen before the fetch begins instead of after it completes.

### Changes

- **API Endpoint**: Added `/api/directories/` JSON endpoint for directory tree
- **Async Loading**: Client-side fetch and render of directory tree
- **Loading Screen**: Updated lifecycle - shows before fetch, hides after render
- **Error Handling**: User-friendly error message with retry option
- **Tests**: Added Django tests for the API endpoint

### Bug Fixes

- Fixed unreachable error message in `SettingView.post()`
- Fixed duplicate DOM IDs in `buildDirectoryTree()`

### Files Changed

- `importer/urls.py` - Added API route
- `importer/views.py` - Added DirectoryListView
- `importer/templates/importer.html` - Updated for async loading
- `importer/templates/importer.js` - Added fetch and render logic
- `importer/templates/base.html` - Updated loading screen lifecycle
- `importer/tests.py` - Added API tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory tree now loads dynamically from an API with loading, error and retry UI states; client-side rendering populates the tree.
  * Pre-loader behavior adjusted: auto-hides on most pages but remains visible on the import page.

* **Bug Fixes**
  * Fixed import panel CSS typo (min-height).
  * Improved loading overlay removal and retry handling for directory loading.

* **Tests**
  * Added comprehensive tests for the directory API and tree-building logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->