### PR TITLE
feat(ui): add book counts to status tabs

### DIFF
--- a/importer/templates/book_tabs.html
+++ b/importer/templates/book_tabs.html
@@ -3,9 +3,9 @@
 <div class="box">
     <div class="tabs is-fullwidth is-toggle" style="background: white;" data-default={{ default_view }}>
         <ul>
-            <li class="tab is-active" id="done-tab" onclick="openTab('done')"><a aria-label="Done - {{ done_books|length }} books">Done ({{ done_books|length }})</a></li>
-            <li class="tab" id="processing-tab" onclick="openTab('processing')"><a aria-label="Processing - {{ processing_books|length }} books">Processing ({{ processing_books|length }})</a></li>
-            <li class="tab" id="error-tab" onclick="openTab('error')"><a aria-label="Error - {{ error_books|length }} books">Error ({{ error_books|length }})</a></li>
+            <li class="tab is-active" id="done-tab" onclick="openTab('done')"><a aria-label="Done - {{ done_books|length }} book{{ done_books|length|pluralize }}">Done ({{ done_books|length }})</a></li>
+            <li class="tab" id="processing-tab" onclick="openTab('processing')"><a aria-label="Processing - {{ processing_books|length }} book{{ processing_books|length|pluralize }}">Processing ({{ processing_books|length }})</a></li>
+            <li class="tab" id="error-tab" onclick="openTab('error')"><a aria-label="Error - {{ error_books|length }} book{{ error_books|length|pluralize }}">Error ({{ error_books|length }})</a></li>
         </ul>
     </div>
 

--- a/importer/templates/book_tabs.html
+++ b/importer/templates/book_tabs.html
@@ -3,9 +3,9 @@
 <div class="box">
     <div class="tabs is-fullwidth is-toggle" style="background: white;" data-default={{ default_view }}>
         <ul>
-            <li class="tab is-active" id="done-tab" onclick="openTab('done')"><a>Done</a></li>
-            <li class="tab" id="processing-tab" onclick="openTab('processing')"><a>Processing</a></li>
-            <li class="tab" id="error-tab" onclick="openTab('error')"><a>Error</a></li>
+            <li class="tab is-active" id="done-tab" onclick="openTab('done')"><a aria-label="Done - {{ done_books|length }} books">Done ({{ done_books|length }})</a></li>
+            <li class="tab" id="processing-tab" onclick="openTab('processing')"><a aria-label="Processing - {{ processing_books|length }} books">Processing ({{ processing_books|length }})</a></li>
+            <li class="tab" id="error-tab" onclick="openTab('error')"><a aria-label="Error - {{ error_books|length }} books">Error ({{ error_books|length }})</a></li>
         </ul>
     </div>
 


### PR DESCRIPTION
## Summary

Adds dynamic book counts to the Done, Processing, and Error tabs on the books page.

## Changes

- Modified `importer/templates/book_tabs.html` to display counts using existing template variables
- Format: "Done (N)", "Processing (N)", "Error (N)"
- Added `aria-label` attributes for accessibility
- Zero counts displayed as "(0)" (e.g., "Error (0)")

## Testing

- Verified with Playwright: all tab counts display correctly
- Tab switching functionality preserved
- No new database queries (uses existing context data)

## Related

- Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Tab labels now show real-time counts for each status (Done, Processing, Error) to make item totals visible at a glance.
  * Improved accessibility: tab controls include descriptive labels for screen readers indicating status and item count.
  * Visual/behavior of tab content remains unchanged—only the visible labels and accessibility text were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->